### PR TITLE
Statistics element

### DIFF
--- a/docs/examples/views/StatisticExample/Statistic.example.vue
+++ b/docs/examples/views/StatisticExample/Statistic.example.vue
@@ -1,0 +1,29 @@
+<template lang="html">
+  <div>
+    <div class="single-example">
+      <sui-statistic>
+        <sui-statistic-value>5,550</sui-statistic-value>
+        <sui-statistic-label>Downloads</sui-statistic-label>
+      </sui-statistic>
+    </div>
+
+    <div class="single-example">
+      <sui-statistic>
+        <sui-statistic-label>Downloads</sui-statistic-label>
+        <sui-statistic-value>5,550</sui-statistic-value>
+      </sui-statistic>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'StatisticExample',
+};
+</script>
+
+<style>
+  .single-example {
+    padding: 20px 0;
+  }
+</style>

--- a/docs/examples/views/StatisticExample/StatisticColored.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticColored.example.vue
@@ -101,6 +101,6 @@
 
 <script>
 export default {
-  name: 'StatisticGroupExample',
+  name: 'StatisticColoredExample',
 };
 </script>

--- a/docs/examples/views/StatisticExample/StatisticColored.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticColored.example.vue
@@ -1,0 +1,106 @@
+<template lang="html">
+  <sui-statistics-group>
+    <sui-statistic inGroup color="red">
+      <sui-statistic-value>
+        27
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Red
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup color="orange">
+      <sui-statistic-value>
+        8
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Orange
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup color="yellow">
+      <sui-statistic-value>
+        28
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Yellow
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup color="olive">
+      <sui-statistic-value>
+        7
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Olive
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup color="green">
+      <sui-statistic-value>
+        14
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Green
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup color="teal">
+      <sui-statistic-value>
+        82
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Teal
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup color="blue">
+      <sui-statistic-value>
+        1
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Blue
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup color="violet">
+      <sui-statistic-value>
+        22
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Violet
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup color="purple">
+      <sui-statistic-value>
+        23
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Purple
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup color="pink">
+      <sui-statistic-value>
+        15
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Pink
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup color="brown">
+      <sui-statistic-value>
+        36
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Brown
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup color="grey">
+      <sui-statistic-value>
+        49
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Grey
+      </sui-statistic-label>
+    </sui-statistic>
+  </sui-statistics-group>
+</template>
+
+<script>
+export default {
+  name: 'StatisticGroupExample',
+};
+</script>

--- a/docs/examples/views/StatisticExample/StatisticContentLabel.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticContentLabel.example.vue
@@ -1,0 +1,18 @@
+<template lang="html">
+  <sui-statistic>
+    <sui-statistic-value>2,204</sui-statistic-value>
+    <sui-statistic-label>Views</sui-statistic-label>
+  </sui-statistic>
+</template>
+
+<script>
+export default {
+  name: 'StatisticExample',
+};
+</script>
+
+<style>
+  .single-example {
+    padding: 20px 0;
+  }
+</style>

--- a/docs/examples/views/StatisticExample/StatisticContentLabel.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticContentLabel.example.vue
@@ -7,12 +7,6 @@
 
 <script>
 export default {
-  name: 'StatisticExample',
+  name: 'StatisticContentLabelExample',
 };
 </script>
-
-<style>
-  .single-example {
-    padding: 20px 0;
-  }
-</style>

--- a/docs/examples/views/StatisticExample/StatisticContentValue.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticContentValue.example.vue
@@ -1,0 +1,50 @@
+<template lang="html">
+  <sui-statistics-group>
+    <sui-statistic inGroup>
+      <sui-statistic-value>
+        22
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Saves
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup>
+      <sui-statistic-value text>
+        Three<br>
+        Thousand
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Signups
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup>
+      <sui-statistic-value>
+        <i class="plane icon"></i> 5
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Flights
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup>
+      <sui-statistic-value>
+        <img src="static/images/avatar/small/joe.jpg" class="ui circular inline image">
+        42
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Team Members
+      </sui-statistic-label>
+    </sui-statistic>
+  </sui-statistics-group>
+</template>
+
+<script>
+export default {
+  name: 'StatisticExample',
+};
+</script>
+
+<style>
+  .single-example {
+    padding: 20px 0;
+  }
+</style>

--- a/docs/examples/views/StatisticExample/StatisticContentValue.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticContentValue.example.vue
@@ -39,12 +39,6 @@
 
 <script>
 export default {
-  name: 'StatisticExample',
+  name: 'StatisticContentValueExample',
 };
 </script>
-
-<style>
-  .single-example {
-    padding: 20px 0;
-  }
-</style>

--- a/docs/examples/views/StatisticExample/StatisticEvenlyDivided.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticEvenlyDivided.example.vue
@@ -1,0 +1,44 @@
+<template lang="html">
+  <sui-statistics-group :columns="4">
+    <sui-statistic inGroup>
+      <sui-statistic-value>
+        22
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Saves
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup>
+      <sui-statistic-value text>
+        Three<br>
+        Thousand
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Signups
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup>
+      <sui-statistic-value>
+        <i class="plane icon"></i> 5
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Flights
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup>
+      <sui-statistic-value>
+        <img src="static/images/avatar/small/joe.jpg" class="ui circular inline image">
+        42
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Team Members
+      </sui-statistic-label>
+    </sui-statistic>
+  </sui-statistics-group>
+</template>
+
+<script>
+export default {
+  name: 'StatisticEvenlyDividedExample',
+};
+</script>

--- a/docs/examples/views/StatisticExample/StatisticFloated.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticFloated.example.vue
@@ -1,0 +1,30 @@
+<template lang="html">
+  <sui-segment>
+    <sui-statistic floated="right">
+      <sui-statistic-value>
+        2,204
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Views
+      </sui-statistic-label>
+    </sui-statistic>
+    <p>Te eum doming eirmod, nominati pertinacia argumentum ad his. Ex eam alia facete scriptorem, est autem aliquip detraxit at. Usu ocurreret referrentur at, cu epicurei appellantur vix. Cum ea laoreet recteque electram, eos choro alterum definiebas in. Vim dolorum definiebas an. Mei ex natum rebum iisque.</p>
+    <p>Audiam quaerendum eu sea, pro omittam definiebas ex. Te est latine definitiones. Quot wisi nulla ex duo. Vis sint solet expetenda ne, his te phaedrum referrentur consectetuer. Id vix fabulas oporteat, ei quo vide phaedrum, vim vivendum maiestatis in.</p>
+    <sui-statistic floated="left">
+      <sui-statistic-value>
+        2,204
+      </sui-statistic-value>
+      <sui-statistic-label class="label">
+        Views
+      </sui-statistic-label>
+    </sui-statistic>
+    <p>Eu quo homero blandit intellegebat. Incorrupte consequuntur mei id. Mei ut facer dolores adolescens, no illum aperiri quo, usu odio brute at. Qui te porro electram, ea dico facete utroque quo. Populo quodsi te eam, wisi everti eos ex, eum elitr altera utamur at. Quodsi convenire mnesarchum eu per, quas minimum postulant per id.</p>
+    <p>Audiam quaerendum eu sea, pro omittam definiebas ex. Te est latine definitiones. Quot wisi nulla ex duo. Vis sint solet expetenda ne, his te phaedrum referrentur consectetuer. Id vix fabulas oporteat, ei quo vide phaedrum, vim vivendum maiestatis in.</p>
+  </sui-segment>
+</template>
+
+<script>
+export default {
+  name: 'StatisticFloatedExample',
+};
+</script>

--- a/docs/examples/views/StatisticExample/StatisticGroup.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticGroup.example.vue
@@ -1,0 +1,22 @@
+<template lang="html">
+  <sui-statistics-group>
+    <sui-statistic inGroup>
+      <sui-statistic-value>22</sui-statistic-value>
+      <sui-statistic-label>Faves</sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup>
+      <sui-statistic-value>31,200</sui-statistic-value>
+      <sui-statistic-label>Views</sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic inGroup>
+      <sui-statistic-value>22</sui-statistic-value>
+      <sui-statistic-label>Members</sui-statistic-label>
+    </sui-statistic>
+  </sui-statistics-group>
+</template>
+
+<script>
+export default {
+  name: 'StatisticGroupExample',
+};
+</script>

--- a/docs/examples/views/StatisticExample/StatisticHorizontal.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticHorizontal.example.vue
@@ -1,0 +1,38 @@
+<template lang="html">
+    <div>
+      <div class="single-example">
+          <sui-statistic horizontal>
+            <sui-statistic-value>2,204</sui-statistic-value>
+            <sui-statistic-label>Views</sui-statistic-label>
+          </sui-statistic>
+      </div>
+      <div class="single-example">
+        <sui-statistics-group horizontal>
+          <sui-statistic inGroup>
+            <sui-statistic-value>22</sui-statistic-value>
+            <sui-statistic-label>Faves</sui-statistic-label>
+          </sui-statistic>
+          <sui-statistic inGroup>
+            <sui-statistic-value>31,200</sui-statistic-value>
+            <sui-statistic-label>Views</sui-statistic-label>
+          </sui-statistic>
+          <sui-statistic inGroup>
+            <sui-statistic-value>22</sui-statistic-value>
+            <sui-statistic-label>Members</sui-statistic-label>
+          </sui-statistic>
+        </sui-statistics-group>
+      </div>
+    </div>
+</template>
+
+<script>
+export default {
+  name: 'StatisticExample',
+};
+</script>
+
+<style>
+  .single-example {
+    padding: 20px 0;
+  }
+</style>

--- a/docs/examples/views/StatisticExample/StatisticHorizontal.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticHorizontal.example.vue
@@ -27,7 +27,7 @@
 
 <script>
 export default {
-  name: 'StatisticExample',
+  name: 'StatisticHorizontalExample',
 };
 </script>
 

--- a/docs/examples/views/StatisticExample/StatisticInverted.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticInverted.example.vue
@@ -1,0 +1,116 @@
+<template lang="html">
+  <sui-segment inverted>
+    <sui-statistics-group>
+      <sui-statistic inverted>
+        <sui-statistic-value>
+          54
+        </sui-statistic-value>
+        <sui-statistic-label>
+          Inverted
+        </sui-statistic-label>
+      </sui-statistic>
+      <sui-statistic color="red" inverted>
+        <sui-statistic-value>
+          27
+        </sui-statistic-value>
+        <sui-statistic-label>
+          Red
+        </sui-statistic-label>
+      </sui-statistic>
+      <sui-statistic color="orange" inverted>
+        <sui-statistic-value>
+          8
+        </sui-statistic-value>
+        <sui-statistic-label>
+          Orange
+        </sui-statistic-label>
+      </sui-statistic>
+      <sui-statistic color="yellow" inverted>
+        <sui-statistic-value>
+          28
+        </sui-statistic-value>
+        <sui-statistic-label>
+          Yellow
+        </sui-statistic-label>
+      </sui-statistic>
+      <sui-statistic color="olive" inverted>
+        <sui-statistic-value>
+          7
+        </sui-statistic-value>
+        <sui-statistic-label>
+          Olive
+        </sui-statistic-label>
+      </sui-statistic>
+        <sui-statistic color="green" inverted>
+        <sui-statistic-value>
+          14
+        </sui-statistic-value>
+        <sui-statistic-label>
+          Green
+        </sui-statistic-label>
+      </sui-statistic>
+      <sui-statistic color="teal" inverted>
+        <sui-statistic-value>
+          82
+        </sui-statistic-value>
+        <sui-statistic-label>
+          Teal
+        </sui-statistic-label>
+      </sui-statistic>
+      <sui-statistic color="blue" inverted>
+        <sui-statistic-value>
+          1
+        </sui-statistic-value>
+        <sui-statistic-label>
+          Blue
+        </sui-statistic-label>
+      </sui-statistic>
+      <sui-statistic color="violet" inverted>
+        <sui-statistic-value>
+          22
+        </sui-statistic-value>
+        <sui-statistic-label>
+          Violet
+        </sui-statistic-label>
+      </sui-statistic>
+      <sui-statistic color="purple" inverted>
+        <sui-statistic-value>
+          23
+        </sui-statistic-value>
+        <sui-statistic-label>
+          Purple
+        </sui-statistic-label>
+      </sui-statistic>
+      <sui-statistic color="pink" inverted>
+        <sui-statistic-value>
+          15
+        </sui-statistic-value>
+        <sui-statistic-label>
+          Pink
+        </sui-statistic-label>
+      </sui-statistic>
+      <sui-statistic color="brown" inverted>
+        <sui-statistic-value>
+          36
+        </sui-statistic-value>
+        <sui-statistic-label>
+          Brown
+        </sui-statistic-label>
+      </sui-statistic>
+      <sui-statistic color="grey" inverted>
+        <sui-statistic-value>
+          49
+        </sui-statistic-value>
+        <sui-statistic-label>
+          Grey
+        </sui-statistic-label>
+      </sui-statistic>
+    </sui-statistics-group>
+  </sui-segment>
+</template>
+
+<script>
+export default {
+  name: 'StatisticInvertedExample',
+};
+</script>

--- a/docs/examples/views/StatisticExample/StatisticSize.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticSize.example.vue
@@ -1,0 +1,113 @@
+<template lang="html">
+  <div>
+    <sui-statistic horizontal size="mini">
+      <sui-statistic-value>
+        2,204
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Views
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic horizontal size="tiny">
+      <sui-statistic-value>
+        2,204
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Views
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic horizontal size="small">
+      <sui-statistic-value>
+        2,204
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Views
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic horizontal>
+      <sui-statistic-value>
+        2,204
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Views
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic horizontal size="large">
+      <sui-statistic-value>
+        2,204
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Views
+      </sui-statistic-label>
+    </sui-statistic>
+    <sui-statistic horizontal size="huge">
+      <sui-statistic-value>
+        2,204
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Views
+      </sui-statistic-label>
+    </sui-statistic>
+
+    <div is="sui-divider" />
+    <sui-statistic horizontal size="mini">
+      <sui-statistic-value>
+        2,204
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Views
+      </sui-statistic-label>
+    </sui-statistic>
+    <div is="sui-divider" />
+    <sui-statistic horizontal size="tiny">
+      <sui-statistic-value>
+        2,204
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Views
+      </sui-statistic-label>
+    </sui-statistic>
+    <div is="sui-divider" />
+    <sui-statistic horizontal size="small">
+      <sui-statistic-value>
+        2,204
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Views
+      </sui-statistic-label>
+    </sui-statistic>
+    <div is="sui-divider" />
+    <sui-statistic horizontal>
+      <sui-statistic-value>
+        2,204
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Views
+      </sui-statistic-label>
+    </sui-statistic>
+    <div is="sui-divider" />
+    <sui-statistic horizontal size="large">
+      <sui-statistic-value>
+        2,204
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Views
+      </sui-statistic-label>
+    </sui-statistic>
+    <div is="sui-divider" />
+    <sui-statistic horizontal size="huge">
+      <sui-statistic-value>
+        2,204
+      </sui-statistic-value>
+      <sui-statistic-label>
+        Views
+      </sui-statistic-label>
+    </sui-statistic>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'StatisticSizeExample',
+};
+</script>

--- a/docs/examples/views/StatisticExample/index.js
+++ b/docs/examples/views/StatisticExample/index.js
@@ -1,0 +1,78 @@
+import Statistic from './Statistic.example';
+import StatisticGroup from './StatisticGroup.example';
+import StatisticContentValue from './StatisticContentValue.example';
+import StatisticContentLabel from './StatisticContentLabel.example';
+import StatisticHorizontal from './StatisticHorizontal.example';
+import StatisticColored from './StatisticColored.example';
+import StatisticInverted from './StatisticInverted.example';
+import StatisticEvenlyDivided from './StatisticEvenlyDivided.example';
+import StatisticFloated from './StatisticFloated.example';
+import StatisticSize from './StatisticSize.example';
+
+export default [
+  {
+    title: 'Types',
+    examples: [
+      {
+        title: 'Statistic',
+        description: 'A statistic can display a value with a label above or below it',
+        component: Statistic,
+      },
+      {
+        title: 'Statistic Group',
+        description: 'A group of statistics',
+        component: StatisticGroup,
+      },
+    ],
+  },
+  {
+    title: 'Content',
+    examples: [
+      {
+        title: 'Value',
+        description: 'A statistic can contain a numeric, icon, image, or text value',
+        component: StatisticContentValue,
+      },
+      {
+        title: 'Label',
+        description: 'A statistic can contain a label to help provide context for the presented value',
+        component: StatisticContentLabel,
+      },
+    ],
+  },
+  {
+    title: 'Variations',
+    examples: [
+      {
+        title: 'Horizontal Statistic',
+        description: 'A statistic can present its measurement horizontally',
+        component: StatisticHorizontal,
+      },
+      {
+        title: 'Colored',
+        description: 'A statistic can be formatted to be different colors',
+        component: StatisticColored,
+      },
+      {
+        title: 'Inverted',
+        description: 'A statistic can be formatted to fit on a dark background',
+        component: StatisticInverted,
+      },
+      {
+        title: 'Evenly Divided',
+        description: 'A statistic group can have its items divided evenly',
+        component: StatisticEvenlyDivided,
+      },
+      {
+        title: 'Floated',
+        description: 'An statistic can sit to the left or right of other content',
+        component: StatisticFloated,
+      },
+      {
+        title: 'Size',
+        description: 'A statistic can vary in size',
+        component: StatisticSize,
+      },
+    ],
+  },
+];

--- a/docs/examples/views/index.js
+++ b/docs/examples/views/index.js
@@ -1,1 +1,2 @@
 export { default as CommentExample } from './CommentExample';
+export { default as StatisticExample } from './StatisticExample';

--- a/src/views/Statistic/Statistic.jsx
+++ b/src/views/Statistic/Statistic.jsx
@@ -1,0 +1,42 @@
+import { classes, getChildProps, getElementType } from '../../lib';
+import { Enum } from '../../lib/PropTypes';
+
+export default {
+  name: 'SuiStatistic',
+  props: {
+    horizontal: {
+      type: Boolean,
+      description: 'Present measurement horizontally',
+    },
+    color: Enum.Color,
+    size: Enum.Size,
+    floated: Enum(['left', 'right']),
+    inverted: {
+      type: Boolean,
+      description: 'Should the colors be inverted',
+    },
+    inGroup: {
+      type: Boolean,
+      description: 'For now manual override, when used inside Statistic Group, to avoid adding extra ui class',
+    },
+  },
+  render() {
+    const ElementType = getElementType(this);
+    return (
+      <ElementType
+        {...getChildProps(this)}
+        class={classes(
+          !this.inGroup && 'ui',
+          'statistic',
+          this.color,
+          this.size,
+          this.floated && `${this.floated} floated`,
+          this.inverted && 'inverted',
+          this.horizontal && 'horizontal',
+        )}
+      >
+        {this.$slots.default}
+      </ElementType>
+    );
+  },
+};

--- a/src/views/Statistic/StatisticGroup.jsx
+++ b/src/views/Statistic/StatisticGroup.jsx
@@ -1,0 +1,29 @@
+import { classes, getChildProps, getElementType, num } from '../../lib';
+
+export default {
+  name: 'SuiStatisticsGroup',
+  props: {
+    horizontal: Boolean,
+    columns: Number,
+  },
+  render() {
+    const ElementType = getElementType(this);
+
+    return (
+      <ElementType
+        {...getChildProps(this)}
+        class={classes(
+          num(this.columns),
+          'ui',
+          'statistics',
+          this.horizontal && 'horizontal',
+        )}
+      >
+        {this.$slots.default}
+      </ElementType>
+    );
+  },
+  meta: {
+    parent: 'SuiStatistic',
+  },
+};

--- a/src/views/Statistic/StatisticLabel.jsx
+++ b/src/views/Statistic/StatisticLabel.jsx
@@ -1,0 +1,21 @@
+import { classes, getChildProps, getElementType } from '../../lib';
+
+export default {
+  name: 'SuiStatisticLabel',
+  props: {
+  },
+  render() {
+    const ElementType = getElementType(this);
+    return (
+      <ElementType
+        {...getChildProps(this)}
+        class={classes('label')}
+      >
+        {this.$slots.default}
+      </ElementType>
+    );
+  },
+  meta: {
+    parent: 'SuiStatistic',
+  },
+};

--- a/src/views/Statistic/StatisticValue.jsx
+++ b/src/views/Statistic/StatisticValue.jsx
@@ -1,0 +1,25 @@
+import { classes, getChildProps, getElementType } from '../../lib';
+
+export default {
+  name: 'SuiStatisticValue',
+  props: {
+    text: Boolean
+  },
+  render() {
+    const ElementType = getElementType(this);
+    return (
+      <ElementType
+        {...getChildProps(this)}
+        class={classes(
+          this.text && 'text',
+          'value'
+        )}
+      >
+        {this.$slots.default}
+      </ElementType>
+    );
+  },
+  meta: {
+    parent: 'SuiStatistic',
+  },
+};

--- a/src/views/Statistic/index.js
+++ b/src/views/Statistic/index.js
@@ -1,0 +1,4 @@
+export { default as Statistic } from './Statistic';
+export { default as StatisticValue } from './StatisticValue';
+export { default as StatisticLabel } from './StatisticLabel';
+export { default as StatisticGroup } from './StatisticGroup';

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -1,2 +1,3 @@
 export * from './Card';
 export * from './Comment';
+export * from './Statistic';


### PR DESCRIPTION
Added statistics element and examples.

Had to hack logic of children `ui` class, when `sui-statistic` is inside of group `sui-statistics`. It would probably be helpful to create global helper, to determine if the component is inside a group or not, since some other components have similar logic, Card for example.