### PR TITLE
Added .gitattributes defaults

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+* text eol=lf
+
+# Graphic formats
+*.jpg binary
+*.jpeg binary
+*.png binary
+*.ico binary
+*.gif binary
+*.tif binary
+*.tiff binary


### PR DESCRIPTION
I have added a .gitattributes file with rules to detect text and convert line endings to LF.

That should make it easier for Windows users to contribute because by default the line endings are converted to CRLF which makes eslint go crazy.