### PR TITLE
Fix minor css bug (doc container)

### DIFF
--- a/docs/ExamplesList.vue
+++ b/docs/ExamplesList.vue
@@ -101,6 +101,7 @@ export default {
   max-width: 960px!important;
   position: relative;
   margin-bottom: 20px;
+  padding:0 15px;
 }
 
 .docs-rail {
@@ -110,6 +111,7 @@ export default {
 @media screen and (min-width: 1200px) {
   .example-list-container {
     margin-right: 387px!important;
+    margin-left: 0 !important;
   }
 
   .docs-rail {


### PR DESCRIPTION
I edit the example list class margin and padding.
The padding is to give some space from the container.