### PR TITLE
Make common Enums extendable

### DIFF
--- a/src/collections/Grid/GridColumn.jsx
+++ b/src/collections/Grid/GridColumn.jsx
@@ -5,7 +5,7 @@ export default {
   name: 'SuiGridColumn',
   description: 'A column sub-component for Grid.',
   props: {
-    color: Enum.Color,
+    color: Enum.Color(),
     width: {
       type: Number,
       description: 'Represents width of column.',

--- a/src/collections/Menu/Menu.jsx
+++ b/src/collections/Menu/Menu.jsx
@@ -7,7 +7,7 @@ export default {
   components: { SuiMenuItem },
   props: {
     activeIndex: Number,
-    color: Enum.Color,
+    color: Enum.Color(),
     compact: Boolean,
     fixed: Boolean,
     icon: Boolean,

--- a/src/collections/Menu/MenuItem.jsx
+++ b/src/collections/Menu/MenuItem.jsx
@@ -7,7 +7,7 @@ export default {
   components: { SuiIcon },
   props: {
     active: Boolean,
-    color: Enum.Color,
+    color: Enum.Color(),
     content: String,
     header: Boolean,
     icon: String,
@@ -27,7 +27,7 @@ export default {
           'item',
         )}
       >
-        {this.icon && <SuiIcon name={this.icon} />}
+        {this.icon && <SuiIcon name={this.icon}/>}
         {this.$slots.default || this.content}
       </ElementType>
     );

--- a/src/collections/Table/Table.jsx
+++ b/src/collections/Table/Table.jsx
@@ -26,7 +26,7 @@ export default {
     stackable: Boolean,
     selectable: Boolean,
     inverted: Boolean,
-    color: Enum.Color,
+    color: Enum.Color(),
     size: Enum(['small', 'large']),
     singleLine: Boolean,
     columns: Number,

--- a/src/collections/Table/TableCell.jsx
+++ b/src/collections/Table/TableCell.jsx
@@ -14,8 +14,8 @@ export default {
     disabled: Boolean,
     selectable: Boolean,
     width: Number,
-    state: Enum.State,
-    verticalAlign: Enum.VerticalAlign,
+    state: Enum.State(),
+    verticalAlign: Enum.VerticalAlign(),
   },
   render() {
     const ElementType = getElementType(this, 'td');

--- a/src/collections/Table/TableHeaderCell.jsx
+++ b/src/collections/Table/TableHeaderCell.jsx
@@ -14,7 +14,7 @@ export default {
     disabled: Boolean,
     selectable: Boolean,
     width: Number,
-    verticalAlign: Enum.VerticalAlign,
+    verticalAlign: Enum.VerticalAlign(),
   },
   render() {
     const ElementType = getElementType(this, 'th');

--- a/src/collections/Table/TableRow.jsx
+++ b/src/collections/Table/TableRow.jsx
@@ -9,8 +9,8 @@ export default {
     selected: Boolean,
     textAlign: Enum(['left', 'right', 'center']),
     warning: Boolean,
-    state: Enum.State,
-    verticalAlign: Enum.VerticalAlign,
+    state: Enum.State(),
+    verticalAlign: Enum.VerticalAlign(),
   },
   render() {
     const ElementType = getElementType(this, 'tr');

--- a/src/elements/Button/Button.jsx
+++ b/src/elements/Button/Button.jsx
@@ -28,7 +28,7 @@ export default {
       type: String,
       description: 'Additional classes.',
     },
-    color: Enum.Color,
+    color: Enum.Color(),
     compact: {
       type: Boolean,
       description: 'A button can reduce its padding to fit into tighter spaces.',
@@ -80,7 +80,7 @@ export default {
       type: Boolean,
       description: 'A button can be formatted to show different levels of emphasis.',
     },
-    size: Enum.Size,
+    size: Enum.Size(),
     tabIndex: {
       type: [Number, String],
       description: 'A button can receive focus.',
@@ -89,7 +89,7 @@ export default {
       type: Boolean,
       description: 'A button can be formatted to toggle on and off.',
     },
-    social: Enum.Social,
+    social: Enum.Social(),
   },
   render() {
     const ElementType = getElementType(this, 'button');

--- a/src/elements/Button/ButtonGroup.jsx
+++ b/src/elements/Button/ButtonGroup.jsx
@@ -9,9 +9,9 @@ export default {
     vertical: Boolean,
     labeled: Boolean,
     icons: Boolean,
-    color: Enum.Color,
+    color: Enum.Color(),
     basic: Boolean,
-    size: Enum.Size,
+    size: Enum.Size(),
   },
   render() {
     const ElementType = getElementType(this);

--- a/src/elements/Header/Header.jsx
+++ b/src/elements/Header/Header.jsx
@@ -4,13 +4,13 @@ import { Enum } from '../../lib/PropTypes';
 export default {
   name: 'SuiHeader',
   props: {
-    color: Enum.Color,
+    color: Enum.Color(),
     content: String,
     dividing: Boolean,
     floated: Enum(['left', 'right']),
     icon: Boolean,
     image: Boolean,
-    size: Enum.Size,
+    size: Enum.Size(),
     sub: Boolean,
   },
   render() {

--- a/src/elements/Icon/Icon.jsx
+++ b/src/elements/Icon/Icon.jsx
@@ -4,7 +4,7 @@ import { Enum } from '../../lib/PropTypes';
 export default {
   name: 'SuiIcon',
   props: {
-    color: Enum.Color,
+    color: Enum.Color(),
     disabled: Boolean,
     fitted: Boolean,
     name: {
@@ -12,7 +12,7 @@ export default {
       required: true,
     },
     loading: Boolean,
-    size: Enum.Size,
+    size: Enum.Size(),
   },
   render() {
     const ElementType = getElementType(this, 'i');

--- a/src/elements/Label/Label.jsx
+++ b/src/elements/Label/Label.jsx
@@ -8,7 +8,7 @@ export default {
       type: Boolean,
       description: 'A label can reduce its complexity.',
     },
-    color: Enum.Color,
+    color: Enum.Color(),
     image: Boolean,
     pointing: Enum(['left', 'right']),
     ribbon: Boolean,

--- a/src/elements/List/List.jsx
+++ b/src/elements/List/List.jsx
@@ -10,7 +10,7 @@ export default {
     items: Array,
     link: Boolean,
     relaxed: Boolean,
-    size: Enum.Size,
+    size: Enum.Size(),
   },
   render() {
     const ElementType = getElementType(this);

--- a/src/lib/PropTypes.js
+++ b/src/lib/PropTypes.js
@@ -22,11 +22,15 @@ export function Enum(values = [], obj = {}) {
   };
 }
 
-Enum.State = Enum(['active', 'disabled', 'error', 'warning', 'success']);
-Enum.Size = Enum(['mini', 'tiny', 'small', 'standard', 'medium', 'large', 'big', 'huge', 'massive']);
-Enum.Color = Enum([
+Object.defineProperty(Enum, 'Extend', {
+  value: values => (obj = {}) => Enum(values, obj),
+});
+
+Enum.State = Enum.Extend(['active', 'disabled', 'error', 'warning', 'success']);
+Enum.Size = Enum.Extend(['mini', 'tiny', 'small', 'standard', 'medium', 'large', 'big', 'huge', 'massive']);
+Enum.Color = Enum.Extend([
   'red', 'orange', 'yellow', 'olive', 'green', 'teal', 'blue',
   'violet', 'purple', 'pink', 'brown', 'grey', 'black',
 ]);
-Enum.VerticalAlign = Enum(['top', 'middle', 'bottom']);
-Enum.Social = Enum(['facebook', 'twitter', 'google', 'google plus', 'vk', 'instagram', 'linkedin', 'youtube']);
+Enum.VerticalAlign = Enum.Extend(['top', 'middle', 'bottom']);
+Enum.Social = Enum.Extend(['facebook', 'twitter', 'google', 'google plus', 'vk', 'instagram', 'linkedin', 'youtube']);

--- a/src/modules/Progress/Progress.jsx
+++ b/src/modules/Progress/Progress.jsx
@@ -13,9 +13,9 @@ export default {
     progress: Boolean,
     indicating: Boolean,
     indeterminate: Boolean,
-    size: Enum.Size,
-    color: Enum.Color,
-    state: Enum.State,
+    size: Enum.Size(),
+    color: Enum.Color(),
+    state: Enum.State(),
     percent: {
       type: [Number, String],
       default: 50,
@@ -49,14 +49,14 @@ export default {
         )}
         data-percent={this.percent}
       >
-       <div
-         class='bar'
-         style={{
-           width: this.percentString,
-           'transition-duration': '300ms',
-         }}>
-         {this.progress && <div class='progress'> {this.percentString} </div>}
-         </div>
+        <div
+          class='bar'
+          style={{
+            width: this.percentString,
+            'transition-duration': '300ms',
+          }}>
+          {this.progress && <div class='progress'> {this.percentString} </div>}
+        </div>
         {this.label && <div class='label'>{this.label}</div>}
       </ElementType>
     );

--- a/src/views/Statistic/Statistic.jsx
+++ b/src/views/Statistic/Statistic.jsx
@@ -9,8 +9,8 @@ export default {
       type: Boolean,
       description: 'Present measurement horizontally',
     },
-    color: Enum.Color,
-    size: Enum.Size,
+    color: Enum.Color(),
+    size: Enum.Size(),
     floated: Enum(['left', 'right']),
     inverted: {
       type: Boolean,


### PR DESCRIPTION
It is not possible to extend Enum to specify a description or other info for prop when using common Enums, like `Enum.Color`. So i did changes that allow to do like this:
```js
props: {
   color: Enum.Color({
      description: "Some description",
   }),
}
```