### PR TITLE
Elide fitted class when checkbox label is set via default slot

### DIFF
--- a/src/modules/Checkbox/Checkbox.jsx
+++ b/src/modules/Checkbox/Checkbox.jsx
@@ -53,7 +53,7 @@ export default {
         {...getChildProps(this)}
         class={classes(
           'ui',
-          !this.label && 'fitted',
+          !(this.label || this.$slots.default) && 'fitted',
           this.radio && 'radio',
           this.toggle && 'toggle',
           'checkbox',


### PR DESCRIPTION
This is a refinement for the fix in recently-closed issue #107 

Prevents clipping of label when the label is specified using the
default slot instead of via the label="String" attribute.