### PR TITLE
Checkbox radio improvement

### DIFF
--- a/docs/examples/modules/CheckboxExample/CheckboxDisabled.example.vue
+++ b/docs/examples/modules/CheckboxExample/CheckboxDisabled.example.vue
@@ -1,0 +1,14 @@
+<template lang="html">
+  <div>
+    <sui-checkbox label="checkbox" disabled />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'CheckboxBasicExample',
+};
+</script>
+
+<style lang="css">
+</style>

--- a/docs/examples/modules/CheckboxExample/CheckboxDisabled.example.vue
+++ b/docs/examples/modules/CheckboxExample/CheckboxDisabled.example.vue
@@ -6,7 +6,7 @@
 
 <script>
 export default {
-  name: 'CheckboxBasicExample',
+  name: 'CheckboxDisabledExample',
 };
 </script>
 

--- a/docs/examples/modules/CheckboxExample/RadioDisabled.example.vue
+++ b/docs/examples/modules/CheckboxExample/RadioDisabled.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'RadioExample',
+  name: 'RadioDisabledExample',
 };
 </script>

--- a/docs/examples/modules/CheckboxExample/RadioDisabled.example.vue
+++ b/docs/examples/modules/CheckboxExample/RadioDisabled.example.vue
@@ -1,0 +1,11 @@
+<template lang="html">
+  <div>
+    <sui-checkbox label="Radio choice" radio disabled />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'RadioExample',
+};
+</script>

--- a/docs/examples/modules/CheckboxExample/index.js
+++ b/docs/examples/modules/CheckboxExample/index.js
@@ -1,8 +1,10 @@
 import CheckboxBasic from './CheckboxBasic.example';
 import CheckboxModel from './CheckboxModel.example';
 import CheckboxToggle from './CheckboxToggle.example';
+import CheckboxDisabled from './CheckboxDisabled.example';
 import Radio from './Radio.example';
 import RadioGroup from './RadioGroup.example';
+import RadioDisabled from './RadioDisabled.example';
 import RadioGroupInline from './RadioGroupInline.example';
 
 export default [
@@ -26,6 +28,10 @@ export default [
         component: RadioGroup,
       },
       {
+        description: 'A radio button can be disabled.',
+        component: RadioDisabled,
+      },
+      {
         title: 'Checkbox with two way binding',
         description: 'Checkbox with two way binding',
         component: CheckboxModel,
@@ -34,6 +40,10 @@ export default [
         title: 'Toggle style input',
         description: 'Toggle style input',
         component: CheckboxToggle,
+      },
+      {
+        description: 'A checkbox can be disabled.',
+        component: CheckboxDisabled,
       },
     ],
   },

--- a/src/modules/Checkbox/Checkbox.jsx
+++ b/src/modules/Checkbox/Checkbox.jsx
@@ -7,6 +7,7 @@ export default {
     event: 'change',
   },
   props: {
+    disabled: Boolean,
     inputValue: [Array, Boolean, Number, String],
     label: String,
     radio: Boolean,
@@ -56,6 +57,7 @@ export default {
           !(this.label || this.$slots.default) && 'fitted',
           this.radio && 'radio',
           this.toggle && 'toggle',
+          this.disabled && 'disabled',
           'checkbox',
         )}
       >
@@ -64,7 +66,7 @@ export default {
           class="hidden"
           readonly=""
           tabiindex="0"
-          type="checkbox"
+          type={this.radio ? 'radio' : 'checkbox'}
           checked={this.isChecked}
           onChange={this.setValue}
         />

--- a/test/specs/modules/Checkbox/Checkbox.spec.js
+++ b/test/specs/modules/Checkbox/Checkbox.spec.js
@@ -10,4 +10,20 @@ describe('Checkbox', () => {
     expect(checkbox.find('input').element.getAttribute('type')).to.equal('checkbox');
     expect(checkbox.find('label').element.textContent).to.equal('check');
   });
+
+  it('should create a SUI Radio button with label', () => {
+    const checkbox = shallow(Checkbox, { propsData: { label: 'check', radio: true } });
+    expect(checkbox.find('input').element.getAttribute('type')).to.equal('radio');
+    expect(checkbox.find('label').element.textContent).to.equal('check');
+  });
+
+  it('should create a SUI Checkbox in Disabled mode', () => {
+    const checkbox = shallow(Checkbox, { propsData: { label: 'check', disabled: true } });
+    expect(checkbox.classes()).to.include('disabled');
+  });
+
+  it('should create a SUI Radio button in Disabled mode', () => {
+    const checkbox = shallow(Checkbox, { propsData: { label: 'check', radio: true, disabled: true } });
+    expect(checkbox.classes()).to.include('disabled');
+  });
 });


### PR DESCRIPTION
- Use input type=radio when checkbox is of type Radio (to avoid some
subtle defects I was seeing when the underlying type was checkbox)
- Add support for SUI's disabled attribute on checkbox
- Add examples for radio button
- Add examples for disabled attribute
- Add tests
