### PR TITLE
Prevent events from passing to root

### DIFF
--- a/src/collections/Message/Message.jsx
+++ b/src/collections/Message/Message.jsx
@@ -20,6 +20,11 @@ export default {
     },
     list: Array,
   },
+  events: {
+    dismiss: {
+      custom: true,
+    },
+  },
   methods: {
     handleDismiss() {
       this.$emit('dismiss');

--- a/src/elements/Input/Input.jsx
+++ b/src/elements/Input/Input.jsx
@@ -19,6 +19,11 @@ export default {
     transparent: Boolean,
     value: String,
   },
+  events: {
+    input: {
+      custom: true,
+    },
+  },
   render() {
     const ElementType = getElementType(this);
     let icon;

--- a/src/modules/Checkbox/Checkbox.jsx
+++ b/src/modules/Checkbox/Checkbox.jsx
@@ -15,6 +15,11 @@ export default {
     toggle: Boolean,
     value: String,
   },
+  events: {
+    change: {
+      custom: true,
+    },
+  },
   computed: {
     isArray() {
       return Array.isArray(this.inputValue);

--- a/src/modules/Dropdown/Dropdown.jsx
+++ b/src/modules/Dropdown/Dropdown.jsx
@@ -101,6 +101,11 @@ export default {
       description: 'Whether or not the menu should close when the dropdown is blurred.',
     },
   },
+  events: {
+    input: {
+      custom: true,
+    },
+  },
   data() {
     return {
       filter: '',

--- a/src/modules/Dropdown/DropdownItem.jsx
+++ b/src/modules/Dropdown/DropdownItem.jsx
@@ -38,6 +38,11 @@ export default {
       description: 'Is item selected',
     },
   },
+  events: {
+    select: {
+      custom: true,
+    },
+  },
   methods: {
     select() {
       this.$emit('select', this.value);

--- a/src/modules/Modal/Modal.jsx
+++ b/src/modules/Modal/Modal.jsx
@@ -95,6 +95,17 @@ export default {
       default: true,
     },
   },
+  events: {
+    displayChanged: {
+      custom: true,
+    },
+    [changed]: {
+      custom: true,
+    },
+    clickAwayModal: {
+      custom: true,
+    },
+  },
   data() {
     return {
       offsetY: 0,

--- a/src/modules/Rating/Rating.jsx
+++ b/src/modules/Rating/Rating.jsx
@@ -12,6 +12,11 @@ export default {
     maxRating: Number,
     rating: Number,
   },
+  events: {
+    rate: {
+      custom: true,
+    },
+  },
   data() {
     return {
       selected: 0,


### PR DESCRIPTION
I've added currently known events to `events` option to prevent them from passing to root. Fixes #125 