### PR TITLE
Delete useless tests

### DIFF
--- a/test/specs/elements/Icon/Icon.spec.js
+++ b/test/specs/elements/Icon/Icon.spec.js
@@ -17,10 +17,5 @@ describe('Icon', () => {
     const icon = shallow(Icon, { propsData: { name: 'user' } });
     expect(icon.classes()).to.include('user');
   });
-
-  it('should have a value for name prop', () => {
-    const icon = shallow(Icon, { propsData: { name: 'home' } });
-    expect(icon.hasProp('name', 'home')).to.equal(true);
-  });
 });
 

--- a/test/specs/elements/Image/Image.spec.js
+++ b/test/specs/elements/Image/Image.spec.js
@@ -28,11 +28,6 @@ describe('Image', () => {
     expect(wrappedImage.find('img').element.getAttribute('src')).to.equal(src);
   });
 
-  it('should have a value for name prop', () => {
-    const image = shallow(Image, { propsData: { name: 'home' } });
-    expect(image.hasProp('name', 'home')).to.equal(true);
-  });
-
   it('should work with spaced prop', () => {
     const image = shallow(Image, { propsData: { spaced: true } });
     expect(image.classes()).to.include('spaced');


### PR DESCRIPTION
I wanted to delete `hasProp` usage, but seems, that test, that contain are even useless, since props assignment is already tested in Vue