### PR TITLE
Detect client by using `window` variable instead of `process` in Dropdown

### DIFF
--- a/src/modules/Dropdown/Dropdown.jsx
+++ b/src/modules/Dropdown/Dropdown.jsx
@@ -419,7 +419,7 @@ export default {
       this.$emit('input', this.multipleValue);
     },
     calculateMenuDirection() {
-      if (process.server || !this.menu || !this.menu.$el || !this.open) return;
+      if (!window || !this.menu || !this.menu.$el || !this.open) return;
 
       this.menu.$el.classList.add('loading');
       this.$el.classList.remove('upward');


### PR DESCRIPTION
Fixes #135 