### PR TITLE
Add a Secondary Menu Example

### DIFF
--- a/docs/examples/collections/MenuExample/SecondaryMenu.example.vue
+++ b/docs/examples/collections/MenuExample/SecondaryMenu.example.vue
@@ -1,0 +1,13 @@
+<template lang="html">
+  <sui-menu secondary>
+    <sui-menu-item active link name="Home">Home</sui-menu-item>
+    <sui-menu-item name="Messages">Messages</sui-menu-item>
+    <sui-menu-item name="Friends">Friends</sui-menu-item>
+  </sui-menu>
+</template>
+
+<script>
+export default {
+  name: 'SecondaryMenuExample',
+};
+</script>

--- a/docs/examples/collections/MenuExample/index.js
+++ b/docs/examples/collections/MenuExample/index.js
@@ -1,4 +1,5 @@
 import Menu from './Menu.example';
+import SecondaryMenu from './SecondaryMenu.example';
 
 export default [
   {
@@ -8,6 +9,11 @@ export default [
         title: 'Menu',
         description: 'A menu',
         component: Menu,
+      },
+      {
+        title: 'Secondary Menu',
+        description: 'A menu can adjust its appearance to de-emphasize its contents',
+        component: SecondaryMenu,
       },
     ],
   },


### PR DESCRIPTION
hi there, this pull request is just a placeholder for the future secondary menu example in the documentation.

[Semantic UI secondary menu](https://semantic-ui.com/collections/menu.html#secondary-menu) uses the following HTML/CSS structure
```
<div class="ui secondary menu">
  <a class="active item">
    Home
  </a>
  <a class="item">
    Messages
  </a>
  <a class="item">
    Friends
  </a>

  ...

</div>
```
While Semantic UI Vue (v.0.25)
```
<sui-menu secondary>
  <sui-menu-item active>Home</sui-menu-item>
  <sui-menu-item>Messages</sui-menu-item>
  <sui-menu-item>Friends</sui-menu-item>
</sui-menu>
```
produces the following HTML/CSS
```
<div data-v-115c3d82="" class="ui secondary menu">
  <div class="active item">Home</div>
  <div class="item">Messages</div>
  <div class="item">Friends</div>
</div>
```


