### PR TITLE
Fix dropdown mounted option

### DIFF
--- a/docs/examples/modules/DropdownExample/Dropdown.example.vue
+++ b/docs/examples/modules/DropdownExample/Dropdown.example.vue
@@ -1,80 +1,21 @@
-<script>
-/* eslint-disable */
-</script>
-<template>
-	<div>
-		<h1>Dropdown bug</h1>
-
-		<sui-dropdown
-		  selection
-			v-model="value1"
-			:options="getData2()"
-		/>
-    value1: {{value1}}
-    <br>
-
-		<sui-dropdown
-		  selection
-			v-model="value2"
-			:options="getData2()"
-		/>
-    value2: {{value2}}
-    <br>
-		<sui-dropdown
-		  selection
-			v-model="value3"
-			:options="getData2()"
-		/>
-    value3: {{value3}}
-	</div>
+<template lang="html">
+  <sui-dropdown text="File">
+    <sui-dropdown-menu>
+      <sui-dropdown-item>New</sui-dropdown-item>
+      <sui-dropdown-item>Open... <span class="description">ctrl + o</span></sui-dropdown-item>
+      <sui-dropdown-item>Save as... <span class="description">ctrl + s</span></sui-dropdown-item>
+      <sui-dropdown-item>Rename <span class="description">ctrl + r</span></sui-dropdown-item>
+      <sui-dropdown-item>Make a copy</sui-dropdown-item>
+      <sui-dropdown-item><sui-icon name="folder" />Move to folder</sui-dropdown-item>
+      <sui-dropdown-item><sui-icon name="trash" />Move to trash</sui-dropdown-item>
+      <sui-dropdown-divider/>
+      <sui-dropdown-item>Download as...</sui-dropdown-item>
+    </sui-dropdown-menu>
+  </sui-dropdown>
 </template>
 
 <script>
-const a = [
-        {
-          value: 0,
-          text: "item1"
-        },
-        {
-          value: 1,
-          text: "item2"
-        }
-      ];
-
 export default {
-  methods: {
-    getData() {
-      return [
-        {
-          value: 0,
-          text: "item1"
-        },
-        {
-          value: 1,
-          text: "item2"
-        }
-      ];
-    },
-    getData2() {
-      return [...a];
-    }
-  },
-  data() {
-    return {
-      value1: 0,
-      value2: 1,
-      value3: 0,
-      dataCollection: [
-        {
-          value: 0,
-          text: "item1"
-        },
-        {
-          value: 1,
-          text: "item2"
-        }
-      ]
-    };
-  }
+  name: 'DropdownExample',
 };
 </script>

--- a/docs/examples/modules/DropdownExample/Dropdown.example.vue
+++ b/docs/examples/modules/DropdownExample/Dropdown.example.vue
@@ -1,23 +1,80 @@
-<template lang="html">
-  <sui-dropdown text="File">
-    <sui-dropdown-menu>
-      <sui-dropdown-item>New</sui-dropdown-item>
-      <sui-dropdown-item>Open... <span class="description">ctrl + o</span></sui-dropdown-item>
-      <sui-dropdown-item>Save as... <span class="description">ctrl + s</span></sui-dropdown-item>
-      <sui-dropdown-item>Rename <span class="description">ctrl + r</span></sui-dropdown-item>
-      <sui-dropdown-item>Make a copy</sui-dropdown-item>
-      <sui-dropdown-item><sui-icon name="folder" />Move to folder</sui-dropdown-item>
-      <sui-dropdown-item><sui-icon name="trash" />Move to trash</sui-dropdown-item>
-      <sui-dropdown-divider/>
-      <sui-dropdown-item>Download as...</sui-dropdown-item>
-    </sui-dropdown-menu>
-  </sui-dropdown>
-</div>
+<script>
+/* eslint-disable */
+</script>
+<template>
+	<div>
+		<h1>Dropdown bug</h1>
 
+		<sui-dropdown
+		  selection
+			v-model="value1"
+			:options="getData2()"
+		/>
+    value1: {{value1}}
+    <br>
+
+		<sui-dropdown
+		  selection
+			v-model="value2"
+			:options="getData2()"
+		/>
+    value2: {{value2}}
+    <br>
+		<sui-dropdown
+		  selection
+			v-model="value3"
+			:options="getData2()"
+		/>
+    value3: {{value3}}
+	</div>
 </template>
 
 <script>
+const a = [
+        {
+          value: 0,
+          text: "item1"
+        },
+        {
+          value: 1,
+          text: "item2"
+        }
+      ];
+
 export default {
-  name: 'DropdownExample',
+  methods: {
+    getData() {
+      return [
+        {
+          value: 0,
+          text: "item1"
+        },
+        {
+          value: 1,
+          text: "item2"
+        }
+      ];
+    },
+    getData2() {
+      return [...a];
+    }
+  },
+  data() {
+    return {
+      value1: 0,
+      value2: 1,
+      value3: 0,
+      dataCollection: [
+        {
+          value: 0,
+          text: "item1"
+        },
+        {
+          value: 1,
+          text: "item2"
+        }
+      ]
+    };
+  }
 };
 </script>

--- a/src/modules/Dropdown/Dropdown.jsx
+++ b/src/modules/Dropdown/Dropdown.jsx
@@ -266,7 +266,7 @@ export default {
         {value.icon && <Icon name={value.icon} />}
         {value.image && <Image {...{ props: value.image }} />}
         {value.flag && <Flag name={value.flag} />}
-        {value}
+        {value.text}
       </div>;
     },
   },


### PR DESCRIPTION
Fixes #155 

`textNode` was mounting the entire option instead than only the text. Vue was treating the option as a VDOM element, which caused multiple dropdowns sharing the same options not to work.