### PR TITLE
add addition option to dropdowns

### DIFF
--- a/docs/examples/modules/DropdownExample/MultipleSearchSelection.example.vue
+++ b/docs/examples/modules/DropdownExample/MultipleSearchSelection.example.vue
@@ -12,7 +12,7 @@
 
 <script>
 export default {
-  name: 'SearchSelectionExample',
+  name: 'MultipleSearchSelectionExample',
   data() {
     return {
       current: null,

--- a/docs/examples/modules/DropdownExample/MultipleSearchSelectionWithAddition.example.vue
+++ b/docs/examples/modules/DropdownExample/MultipleSearchSelectionWithAddition.example.vue
@@ -1,0 +1,43 @@
+<template lang="html">
+  <sui-dropdown
+    multiple
+    fluid
+    :options="skills"
+    placeholder="Skills"
+    search
+    selection
+    addition
+    v-model="current"
+  />
+</template>
+
+<script>
+export default {
+  name: 'SearchSelectionExample',
+  data() {
+    return {
+      current: null,
+      skills: [
+        { key: 'angular', text: 'Angular', value: 'angular' },
+        { key: 'css', text: 'CSS', value: 'css' },
+        { key: 'design', text: 'Graphic Design', value: 'design' },
+        { key: 'ember', text: 'Ember', value: 'ember' },
+        { key: 'html', text: 'HTML', value: 'html' },
+        { key: 'ia', text: 'Information Architecture', value: 'ia' },
+        { key: 'javascript', text: 'Javascript', value: 'javascript' },
+        { key: 'mech', text: 'Mechanical Engineering', value: 'mech' },
+        { key: 'meteor', text: 'Meteor', value: 'meteor' },
+        { key: 'node', text: 'NodeJS', value: 'node' },
+        { key: 'plumbing', text: 'Plumbing', value: 'plumbing' },
+        { key: 'python', text: 'Python', value: 'python' },
+        { key: 'rails', text: 'Rails', value: 'rails' },
+        { key: 'react', text: 'React', value: 'react' },
+        { key: 'repair', text: 'Kitchen Repair', value: 'repair' },
+        { key: 'ruby', text: 'Ruby', value: 'ruby' },
+        { key: 'ui', text: 'UI Design', value: 'ui' },
+        { key: 'ux', text: 'User Experience', value: 'ux' },
+      ],
+    };
+  },
+};
+</script>

--- a/docs/examples/modules/DropdownExample/MultipleSearchSelectionWithAddition.example.vue
+++ b/docs/examples/modules/DropdownExample/MultipleSearchSelectionWithAddition.example.vue
@@ -6,14 +6,14 @@
     placeholder="Skills"
     search
     selection
-    addition
+    allowAdditions
     v-model="current"
   />
 </template>
 
 <script>
 export default {
-  name: 'SearchSelectionExample',
+  name: 'MultipleSearchSelectionWithAdditionExample',
   data() {
     return {
       current: null,

--- a/docs/examples/modules/DropdownExample/MultipleSearchSelectionWithAddition.example.vue
+++ b/docs/examples/modules/DropdownExample/MultipleSearchSelectionWithAddition.example.vue
@@ -6,7 +6,7 @@
     placeholder="Skills"
     search
     selection
-    allowAdditions
+    allow-additions
     v-model="current"
   />
 </template>

--- a/docs/examples/modules/DropdownExample/MultipleSelection.example.vue
+++ b/docs/examples/modules/DropdownExample/MultipleSelection.example.vue
@@ -11,7 +11,7 @@
 
 <script>
 export default {
-  name: 'SearchSelectionExample',
+  name: 'MultipleSelectionExample',
   data() {
     return {
       current: null,

--- a/docs/examples/modules/DropdownExample/index.js
+++ b/docs/examples/modules/DropdownExample/index.js
@@ -6,6 +6,7 @@ import FriendSelection from './FriendSelection.example';
 import MultipleSelection from './MultipleSelection.example';
 import MultipleMaxSelections from './MultipleMaxSelections.example';
 import MultipleSearchSelection from './MultipleSearchSelection.example';
+import MultipleSearchSelectionWithAddition from './MultipleSearchSelectionWithAddition.example';
 import Selection from './Selection.example';
 import SearchDropdown from './SearchDropdown.example';
 import SearchSelection from './SearchSelection.example';
@@ -45,6 +46,11 @@ export default [
         title: 'Multiple Search Selection',
         description: 'A selection dropdown can allow multiple search selections.',
         component: MultipleSearchSelection,
+      },
+      {
+        title: 'Multiple Search Selection With Additions',
+        description: 'A selection dropdown can allow multiple search selections and user additions.',
+        component: MultipleSearchSelectionWithAddition,
       },
       {
         title: 'Search Dropdown',

--- a/src/modules/Dropdown/Dropdown.jsx
+++ b/src/modules/Dropdown/Dropdown.jsx
@@ -32,7 +32,7 @@ export default {
   name: 'SuiDropdown',
   mixins: [SemanticUIVueMixin],
   props: {
-    addition: {
+    allowAdditions: {
       type: Boolean,
       description: 'A dropdown can allow user additions.'
     },
@@ -184,7 +184,7 @@ export default {
             return `Max ${this.maxSelections} selections`;
           }
         }
-        if (this.filter && !this.addition) {
+        if (this.filter && !this.allowAdditions) {
           return 'No results found';
         }
       }
@@ -232,7 +232,7 @@ export default {
       }
       return this.multipleValue.map((value) => {
         const existingOption = this.findOption(value)
-        const option = this.addition && !existingOption ? {text: value} : existingOption;
+        const option = this.allowAdditions && !existingOption ? {text: value} : existingOption;
         return (
           <Label nativeOnClick={this.handleClickOnSelectedNode}>
             {option.icon && <Icon name={option.icon} />}
@@ -359,7 +359,7 @@ export default {
       switch (e.keyCode) {
         // Handle Enter button
         case 13:
-          if (this.addition && this.selectedIndex === -1 && this.filter.trim() != '') {
+          if (this.allowAdditions && this.selectedIndex === -1 && this.filter.trim() != '') {
             e.preventDefault();
             this.selectItem(this.filter)
           } else if (this.selection) {

--- a/src/modules/Dropdown/Dropdown.jsx
+++ b/src/modules/Dropdown/Dropdown.jsx
@@ -301,7 +301,6 @@ export default {
       }
     },
     closeMenu() {
-      debugger;
       this.setOpen(false);
     },
     deselectItem(selectedValue) {

--- a/src/modules/Dropdown/Dropdown.jsx
+++ b/src/modules/Dropdown/Dropdown.jsx
@@ -32,6 +32,10 @@ export default {
   name: 'SuiDropdown',
   mixins: [SemanticUIVueMixin],
   props: {
+    addition: {
+      type: Boolean,
+      description: 'A dropdown can allow user additions.'
+    },
     button: {
       type: Boolean,
       description: 'A dropdown button style.',
@@ -180,7 +184,7 @@ export default {
             return `Max ${this.maxSelections} selections`;
           }
         }
-        if (this.filter) {
+        if (this.filter && !this.addition) {
           return 'No results found';
         }
       }
@@ -227,7 +231,8 @@ export default {
         return null;
       }
       return this.multipleValue.map((value) => {
-        const option = this.findOption(value);
+        const existingOption = this.findOption(value)
+        const option = this.addition && !existingOption ? {text: value} : existingOption;
         return (
           <Label nativeOnClick={this.handleClickOnSelectedNode}>
             {option.icon && <Icon name={option.icon} />}
@@ -288,11 +293,15 @@ export default {
   methods: {
     setOpen(value = true) {
       this.open = value;
+      if (this.search && this.filteredOptions.length >= 0) {
+        this.selectedIndex = 0;
+      }
       if (this.menu) {
         this.menu.setOpen(value);
       }
     },
     closeMenu() {
+      debugger;
       this.setOpen(false);
     },
     deselectItem(selectedValue) {
@@ -351,11 +360,13 @@ export default {
       switch (e.keyCode) {
         // Handle Enter button
         case 13:
-          if (this.selection) {
+          if (this.addition && this.selectedIndex === -1 && this.filter.trim() != '') {
+            e.preventDefault();
+            this.selectItem(this.filter)
+          } else if (this.selection) {
             if (this.selectedIndex === -1) return;
             e.preventDefault();
             if (!this.multiple) {
-              this.filter = '';
               this.setOpen(false);
             } else {
               this.selectItem(this.filteredOptions[this.selectedIndex].value);
@@ -397,8 +408,8 @@ export default {
         this.multipleValue.filter(value => value !== selectedValue).concat(selectedValue)
       ) : selectedValue;
       this.$emit('input', newValue);
+      this.filter = '';
       if (!this.multiple) {
-        this.filter = '';
         this.$nextTick(this.updateSelectedIndex);
       }
     },

--- a/src/modules/Dropdown/Dropdown.jsx
+++ b/src/modules/Dropdown/Dropdown.jsx
@@ -34,7 +34,7 @@ export default {
   props: {
     allowAdditions: {
       type: Boolean,
-      description: 'A dropdown can allow user additions.'
+      description: 'A dropdown can allow user additions.',
     },
     button: {
       type: Boolean,
@@ -231,8 +231,8 @@ export default {
         return null;
       }
       return this.multipleValue.map((value) => {
-        const existingOption = this.findOption(value)
-        const option = this.allowAdditions && !existingOption ? {text: value} : existingOption;
+        const existingOption = this.findOption(value);
+        const option = this.allowAdditions && !existingOption ? { text: value } : existingOption;
         return (
           <Label nativeOnClick={this.handleClickOnSelectedNode}>
             {option.icon && <Icon name={option.icon} />}
@@ -359,9 +359,9 @@ export default {
       switch (e.keyCode) {
         // Handle Enter button
         case 13:
-          if (this.allowAdditions && this.selectedIndex === -1 && this.filter.trim() != '') {
+          if (this.allowAdditions && this.selectedIndex === -1 && this.filter.trim() !== '') {
             e.preventDefault();
-            this.selectItem(this.filter)
+            this.selectItem(this.filter);
           } else if (this.selection) {
             if (this.selectedIndex === -1) return;
             e.preventDefault();


### PR DESCRIPTION
This will add a new option, `addition` which if set to true allows user specified items to be added. As discussed in #168 the default behaviour changes a little bit in the sense that when a searchable dropdown is opened it will highlight the first available option to mimic the original behaviour of semantic. It will also clear the filter after pressing enter on a searchable dropdown, also to mimic the original behaviour.

 I could do with some help in terms of writing tests for this as I am a bit lost there.
