### PR TITLE
Add more button colors

### DIFF
--- a/src/elements/Button/Button.jsx
+++ b/src/elements/Button/Button.jsx
@@ -29,7 +29,7 @@ export default {
       type: String,
       description: 'Additional classes.',
     },
-    color: Enum.Color(),
+    color: Enum.ButtonColor(),
     compact: {
       type: Boolean,
       description: 'A button can reduce its padding to fit into tighter spaces.',

--- a/src/lib/PropTypes.js
+++ b/src/lib/PropTypes.js
@@ -40,6 +40,12 @@ Enum.Color = Enum.Extend([
   'red', 'orange', 'yellow', 'olive', 'green', 'teal', 'blue',
   'violet', 'purple', 'pink', 'brown', 'grey', 'black',
 ]);
+Enum.ButtonColor = Enum.Extend([
+  'red', 'orange', 'yellow', 'olive', 'green', 'teal', 'blue',
+  'violet', 'purple', 'pink', 'brown', 'grey', 'black',
+  'primary', 'secondary',
+  'positive', 'negative',
+]);
 Enum.Attached = Enum.Extend(['top', 'bottom']);
 Enum.TextAlign = Enum.Extend(['left', 'right', 'center', 'justify']);
 Enum.VerticalAlign = Enum.Extend(['top', 'middle', 'bottom']);


### PR DESCRIPTION
As the original [docs](https://semantic-ui.com/elements/button.html#positive) states you can modify the colors by adding `positive` and `negative` to buttons. You can also use `primary` and `secondary` as colors. This will work as value and render correctly but it throws validation errors. As `positive` and `negative` will only work on buttons these need to have their own enumeration.