### PR TITLE
Add blur event to inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-ui-vue",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "Semantic-UI Vue integration",
   "author": "Mario Lamacchia <mario.lamacchia@mariolamacchia.com>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "semantic-ui-vue",
-  "version": "0.2.11",
+  "version": "0.2.10",
   "description": "Semantic-UI Vue integration",
   "author": "Mario Lamacchia <mario.lamacchia@mariolamacchia.com>",
   "repository": {

--- a/src/elements/Input/Input.jsx
+++ b/src/elements/Input/Input.jsx
@@ -51,6 +51,7 @@ export default {
         <input
           value={this.value}
           onInput={e => this.$emit('input', e.target.value)}
+          onBlur={e => this.$emit('blur', e)}
           {...{ attrs: this.$attrs }}
         />
         {icon}

--- a/src/elements/Input/Input.jsx
+++ b/src/elements/Input/Input.jsx
@@ -23,6 +23,9 @@ export default {
     input: {
       custom: true,
     },
+    blur: {
+      custom: true,
+    },
   },
   render() {
     const ElementType = this.getElementType();


### PR DESCRIPTION
This allows `sui-input` to have the blur event bound to it. It's a small and quick patch but should probably be expanded at a later date to allow all the same bindings a standard input does