### PR TITLE
Fix IE 11 modal glitch

### DIFF
--- a/src/modules/Modal/Modal.jsx
+++ b/src/modules/Modal/Modal.jsx
@@ -111,13 +111,13 @@ export default {
     },
     dimmerStyle() {
       return {
-        display: this.visible ? 'flex !important' : 'none',
+        display: this.visible ? 'flex' : 'none',
         animationDuration: `${this.animationDuration}ms`,
       };
     },
     modalStyle() {
       return {
-        display: this.visible ? 'block !important' : 'none',
+        display: this.visible ? 'block' : 'none',
         animationDuration: `${this.animationDuration}ms`,
       };
     },

--- a/src/modules/Modal/Modal.jsx
+++ b/src/modules/Modal/Modal.jsx
@@ -111,13 +111,13 @@ export default {
     },
     dimmerStyle() {
       return {
-        display: this.visible ? 'flex' : 'none',
+        display: this.visible ? 'flex !important' : 'none !important',
         animationDuration: `${this.animationDuration}ms`,
       };
     },
     modalStyle() {
       return {
-        display: this.visible ? 'block' : 'none',
+        display: this.visible ? 'block !important' : 'none !important',
         animationDuration: `${this.animationDuration}ms`,
       };
     },


### PR DESCRIPTION
For some reason, the `!important` causes issues in IE 11.540 (and possibly other versions). Adding `!important` to the `display: none` [fixes these issues](https://github.com/vuejs/vue/issues/8415#issuecomment-400559373). This resolves #191.

Minimal reproduction to show IE `!important` failure: https://codepen.io/anon/pen/QxVRyW?editors=1010