### PR TITLE
Missing 'path' property on mouseEvent click objects

### DIFF
--- a/src/modules/Dropdown/Dropdown.jsx
+++ b/src/modules/Dropdown/Dropdown.jsx
@@ -323,6 +323,9 @@ export default {
       e.stopPropagation();
       if (this.open) {
         if (this.search && e.target === this.$refs.search) return;
+        if (!e.path) {
+          this.addEventPath()
+        }
         if (this.multiple && e.path.indexOf(this.menu.$el) !== -1) {
           this.$nextTick(() => this.focusSearch());
           return;
@@ -330,6 +333,25 @@ export default {
       }
       this.focusSearch();
       this.setOpen(!this.open);
+    },
+    addEventPath: function() {
+      if (!('path' in Event.prototype)) {
+        Object.defineProperty(Event.prototype, 'path', {
+          get: function () {
+            const path = [];
+            let currentElem = this.target;
+            while (currentElem) {
+              path.push(currentElem);
+              currentElem = currentElem.parentElement;
+            }
+            if (path.indexOf(window) === -1 && path.indexOf(document) === -1)
+              path.push(document);
+            if (path.indexOf(window) === -1)
+              path.push(window);
+            return path;
+          }
+        });
+      }
     },
     handleFocus() {
       if (this.focused) return;


### PR DESCRIPTION
Specifically for non-chrome browsers. 