### PR TITLE
Allow center positioning for submenu blocks

### DIFF
--- a/src/collections/Menu/MenuMenu.jsx
+++ b/src/collections/Menu/MenuMenu.jsx
@@ -5,8 +5,8 @@ export default {
   name: 'SuiMenuMenu',
   mixins: [SemanticUIVueMixin],
   props: {
-    position: Enum(['left', 'right'], {
-      description: 'A sub menu can take left or right position',
+    position: Enum(['left', 'center', 'right'], {
+      description: 'A sub menu can take left, center or right position',
     }),
   },
   render() {


### PR DESCRIPTION
Semantic-UI allows center positioning of submenu items. Semantic-UI-vue should allow it too.