### PR TITLE
 Fix #145: Allow label to act as corner within an image

### DIFF
--- a/docs/examples/elements/LabelExample/CornerImage.example.vue
+++ b/docs/examples/elements/LabelExample/CornerImage.example.vue
@@ -1,0 +1,12 @@
+<template lang="html">
+  <sui-image wrapped src="static/images/wireframes/image.png">
+    <sui-label slot="corner" corner="left"><sui-icon name="star" /></sui-label>
+  </sui-image>
+</template>
+
+<script>
+export default {};
+</script>
+
+<style lang="css">
+</style>

--- a/docs/examples/elements/LabelExample/CornerImage.example.vue
+++ b/docs/examples/elements/LabelExample/CornerImage.example.vue
@@ -1,7 +1,17 @@
 <template lang="html">
-  <sui-image wrapped src="static/images/wireframes/image.png">
-    <sui-label slot="corner" corner="left"><sui-icon name="star" /></sui-label>
-  </sui-image>
+  <sui-grid>
+    <sui-grid-column :width="6">
+      <sui-image src="static/images/wireframes/image.png">
+        <sui-label slot="corner" corner="left"><sui-icon name="save" /></sui-label>
+      </sui-image>
+    </sui-grid-column>
+
+    <sui-grid-column :width="6">
+      <sui-image wrapped src="static/images/wireframes/image.png">
+        <sui-label slot="corner" corner="right"><sui-icon name="cancel" /></sui-label>
+      </sui-image>
+    </sui-grid-column>
+  </sui-grid>
 </template>
 
 <script>

--- a/docs/examples/elements/LabelExample/index.js
+++ b/docs/examples/elements/LabelExample/index.js
@@ -2,6 +2,7 @@ import Label from './Label.example';
 import Image from './Image.example';
 import Image2 from './Image2.example';
 import Image3 from './Image3.example';
+import CornerImage from './CornerImage.example';
 
 export default [
   {
@@ -22,6 +23,11 @@ export default [
       },
       {
         component: Image3,
+      },
+      {
+        title: 'Corner',
+        description: 'A label can position itself in the corner of an element',
+        component: CornerImage,
       },
     ],
   },

--- a/src/elements/Image/Image.jsx
+++ b/src/elements/Image/Image.jsx
@@ -40,6 +40,7 @@ export default {
     if (this.wrapped) {
       return (
         <ElementType class={classNames}>
+          {this.$slots.corner}
           <img src={this.src} />
         </ElementType>
       );

--- a/src/elements/Image/Image.jsx
+++ b/src/elements/Image/Image.jsx
@@ -37,7 +37,7 @@ export default {
       'image',
     );
 
-    if (this.wrapped) {
+    if (this.wrapped || this.$slots.corner) {
       return (
         <ElementType class={classNames}>
           {this.$slots.corner}

--- a/src/elements/Label/Label.jsx
+++ b/src/elements/Label/Label.jsx
@@ -13,6 +13,9 @@ export default {
     image: Boolean,
     pointing: Enum(['left', 'right']),
     ribbon: Boolean,
+    corner: Enum(['left', 'right'], {
+      description: 'A label can position itself in the corner of an element.',
+    }),
   },
   render() {
     const ElementType = this.getElementType();
@@ -26,6 +29,7 @@ export default {
           this.basic && 'basic',
           this.image && 'image',
           this.ribbon && 'ribbon',
+          this.corner && `${this.corner} corner`,
           'label',
         )}
       >


### PR DESCRIPTION
Example:

```html
<sui-image src="static/images/wireframes/image.png">
   <sui-label slot="corner" corner="left"><sui-icon name="star" /></sui-label>
</sui-image>
```
I went with **corner** instead of **before** as slot name for the image element but I'm not sure if you want to let other components use the corner label. In that case, I should probably rename the slot to something like "before" or "label".