### PR TITLE
fix bug in dropdown when using arrow key without text

### DIFF
--- a/src/modules/Dropdown/Dropdown.jsx
+++ b/src/modules/Dropdown/Dropdown.jsx
@@ -362,7 +362,9 @@ export default {
       if (!this.multiple && filter.trim() === '') filteredText.classList.remove('filtered');
     },
     handleKeyDown(e) {
-      this.toggleFilteredText(this.$refs.text, this.filter);
+      if(this.$refs.text){
+        this.toggleFilteredText(this.$refs.text, this.filter);
+      }
       const KEYS = {
         ENTER: 13,
         ESCAPE: 27,


### PR DESCRIPTION
fix bug in dropdown when using arrow key without text

![2018-09-30 22 46 24](https://user-images.githubusercontent.com/5773419/46262516-af82ee00-c502-11e8-81ff-a25b7ca11e8c.jpg)
