### PR TITLE
Fix props toggle on Mozilla Firefox

### DIFF
--- a/docs/Component.vue
+++ b/docs/Component.vue
@@ -40,7 +40,7 @@
         </sui-list>
 
         <h4 class="props-switcher" is="sui-header" :color="propSwitcherColor">
-          <a href="javascript:void 0" @click="toggleProps">
+          <a href="#" @click="toggleProps">
             <sui-icon :name="propSwitcherIcon" />
             <template v-if="subcomponents.length">
               Props:
@@ -193,7 +193,9 @@ export default {
     },
   },
   methods: {
-    toggleProps() {
+    toggleProps(event) {
+      event.preventDefault();
+
       if (this.currentComponent) {
         this.currentComponent = null;
       } else {


### PR DESCRIPTION
The issue was caused by `javascript:void 0` which seems to have a different behavior on different browsers. I've replaced it with '#' which is the standard placeholder nowadays and prevented the default event when triggering the **click** event.

Fixes https://github.com/Semantic-UI-Vue/semantic-ui-vue.github.io/issues/1