### PR TITLE
Fix the props of SuiDropdownItem not displaying on the website

### DIFF
--- a/docs/Component.vue
+++ b/docs/Component.vue
@@ -175,6 +175,10 @@ export default {
             return { name };
           }
 
+          if (!value.type) {
+            return { ...value, name };
+          }
+
           if (typeof value === 'function') {
             return { name, type: value.name };
           }

--- a/docs/Component.vue
+++ b/docs/Component.vue
@@ -184,7 +184,7 @@ export default {
           }
 
           if (value.type instanceof Array) {
-            return { ...value, name, type: value.type.map(type => type.name).join('|') };
+            return { ...value, name, type: value.type.map(type => type.name).join(' | ') };
           }
 
           return { ...value, name, type: value.type.name };


### PR DESCRIPTION
Presumably since #240 the props of `SuiDropdownItem` do not display anymore when the component is selected on the website. The first commit fixes that.

The second commit makes the props type more readable when multiple types are possible. Since it is independent from the fix and depends on preference, I can open a separate PR for that or leave it as is.