### PR TITLE
[fix] typo on event argument

### DIFF
--- a/src/modules/Dropdown/Dropdown.jsx
+++ b/src/modules/Dropdown/Dropdown.jsx
@@ -365,7 +365,7 @@ export default {
       if (this.open) {
         if (this.search && e.target === this.$refs.search) return;
 
-        const path = e.path || (event.composedPath && event.composedPath());
+        const path = e.path || (e.composedPath && e.composedPath());
 
         if (!path) {
           this.addEventPath();


### PR DESCRIPTION
When clicking on an option a ReferenceError is thrown, yielding the following output:

![screenshot_2018-11-20_22-43-48](https://user-images.githubusercontent.com/9020659/48819499-d2b56700-ed15-11e8-8ac9-a04564f77ace.png)
![screenshot_2018-11-20_22-45-20](https://user-images.githubusercontent.com/9020659/48819531-f9739d80-ed15-11e8-8a71-7cec39ebe708.png)

