### PR TITLE
Add missing icon property support

### DIFF
--- a/docs/examples/elements/HeaderExample/IconHeaders.example.vue
+++ b/docs/examples/elements/HeaderExample/IconHeaders.example.vue
@@ -1,6 +1,5 @@
 <template lang="html">
-  <h2 is="sui-header" icon>
-    <sui-icon name="settings" />
+  <h2 is="sui-header" icon="settings">
     Account Settings
     <sui-header-subheader>
       Manage your account settings and set e-mail preferences.

--- a/docs/examples/elements/LabelExample/Icon.example.vue
+++ b/docs/examples/elements/LabelExample/Icon.example.vue
@@ -1,6 +1,9 @@
 <template>
   <div>
-    <a is="sui-label" icon="mail">Mail</a>
+    <a is="sui-label">
+      <sui-icon name="mail" />
+      Mail
+    </a>
     <a is="sui-label">
       Tag
       <sui-icon name="delete" />
@@ -11,4 +14,3 @@
 <script>
 export default {};
 </script>
-

--- a/docs/examples/elements/LabelExample/Icon.example.vue
+++ b/docs/examples/elements/LabelExample/Icon.example.vue
@@ -1,9 +1,6 @@
 <template>
   <div>
-    <a is="sui-label">
-      <sui-icon name="mail" />
-      Mail
-    </a>
+    <a is="sui-label" icon="mail">Mail</a>
     <a is="sui-label">
       Tag
       <sui-icon name="delete" />

--- a/src/elements/Header/Header.jsx
+++ b/src/elements/Header/Header.jsx
@@ -10,7 +10,10 @@ export default {
     dividing: Boolean,
     disabled: Boolean,
     floated: Enum(['left', 'right']),
-    icon: String,
+    icon: {
+      type: [Boolean, String],
+      default: false,
+    },
     image: {
       type: String,
       description: 'Add an image by img src or pass an Image.',
@@ -26,6 +29,7 @@ export default {
   },
   render() {
     const ElementType = this.getElementType();
+
     return (
       <ElementType
         {...this.getChildPropsAndListeners()}
@@ -37,10 +41,10 @@ export default {
           this.attached && 'attached',
           this.color,
           this.size,
+          this.icon && 'icon',
           this.block && 'block',
           this.dividing && 'dividing',
           this.image && 'image',
-          this.icon && 'icon',
           this.sub && 'sub',
           this.disabled && 'disabled',
           this.inverted && 'inverted',
@@ -48,7 +52,7 @@ export default {
         )}
       >
 
-        {this.icon && <sui-icon name={this.icon} />}
+        {this.icon !== !!this.icon && <sui-icon name={this.icon} />}
         {this.image && <img src={this.image} class="ui image" />}
         {this.$slots.default || this.content}
       </ElementType>

--- a/src/elements/Header/Header.jsx
+++ b/src/elements/Header/Header.jsx
@@ -10,7 +10,7 @@ export default {
     dividing: Boolean,
     disabled: Boolean,
     floated: Enum(['left', 'right']),
-    icon: Boolean,
+    icon: String,
     image: {
       type: String,
       description: 'Add an image by img src or pass an Image.',
@@ -39,14 +39,16 @@ export default {
           this.size,
           this.block && 'block',
           this.dividing && 'dividing',
-          this.icon && 'icon',
           this.image && 'image',
+          this.icon && 'icon',
           this.sub && 'sub',
           this.disabled && 'disabled',
           this.inverted && 'inverted',
           'header',
         )}
       >
+
+        {this.icon && <sui-icon name={this.icon} />}
         {this.image && <img src={this.image} class="ui image" />}
         {this.$slots.default || this.content}
       </ElementType>

--- a/src/elements/Label/Label.jsx
+++ b/src/elements/Label/Label.jsx
@@ -33,6 +33,7 @@ export default {
       description: 'A label can point to content next to it.',
       type: Boolean,
     }),
+    icon: String,
     ribbon: Enum(['left', 'right'], {
       description: 'A label can appear as a ribbon attaching itself to an element.',
       type: Boolean,
@@ -81,6 +82,8 @@ export default {
           'label',
         )}
       >
+
+        {this.icon && <sui-icon name={this.icon} />}
         {this.$slots.default}
       </ElementType>
     );

--- a/test/specs/elements/Header/Header.spec.js
+++ b/test/specs/elements/Header/Header.spec.js
@@ -24,11 +24,6 @@ describe('Header', () => {
     expect(header.classes()).to.include('12');
   });
 
-  it('should have a icon class', () => {
-    const header = shallow(Header, { propsData: { icon: true } });
-    expect(header.classes()).to.include('icon');
-  });
-
   it('should have a floated class', () => {
     const header = shallow(Header, { propsData: { floated: 'left' } });
     expect(header.classes()).to.include('floated');
@@ -51,5 +46,11 @@ describe('Header', () => {
 
     const header2 = shallow(Header, { slots: { default: '<span>Content String</span>' } });
     expect(header2.text()).to.equal('Content String');
+  });
+
+  it('should have an icon class', () => {
+    const header = shallow(Header, { propsData: { icon: 'settings' } });
+    expect(header.classes()).to.include('icon');
+    expect(!!header.find('.icon.settings')).to.equal(true);
   });
 });

--- a/test/specs/elements/Label/Label.spec.js
+++ b/test/specs/elements/Label/Label.spec.js
@@ -19,6 +19,15 @@ describe('Label', () => {
     expect(label.classes()).to.include('label');
     expect(label.classes()).to.include('image');
   });
+
+  it('should create a SUI Label with icon', () => {
+    const label = shallow(Label, { propsData: { icon: 'settings' } });
+    expect(label.is('div')).to.equal(true);
+    expect(label.classes()).to.include('ui');
+    expect(label.classes()).to.include('label');
+    expect(!!label.find('.icon.settings')).to.equal(true);
+  });
+
   it('should create a SUI colored Label ', () => {
     const label = shallow(Label, { propsData: { color: 'red' } });
     expect(label.is('div')).to.equal(true);


### PR DESCRIPTION
Add support to `icon` String property for the components below:

- Label (`sui-label`)
- Header (`sui-header`)

Fixes #266 