### PR TITLE
[DropdownMenu]: Corrects Nested Dropdowns not working

### DIFF
--- a/src/modules/Dropdown/DropdownMenu.jsx
+++ b/src/modules/Dropdown/DropdownMenu.jsx
@@ -37,8 +37,9 @@ export default {
   mounted() {
     let parent = this.$parent;
     while (parent && !this.accordion) {
-      if (/^SuiDropdown(WithRequired)?$/.test(parent.$options.name)) {
+      if (parent.$options.name === 'SuiDropdown') {
         this.dropdown = parent;
+        break;
       }
 
       parent = parent.$parent;


### PR DESCRIPTION
Fix for: https://github.com/Semantic-UI-Vue/Semantic-UI-Vue/issues/293

This should also stop it from iterating up the entire DOM tree, which is a nice performance change.

Also changes the regex back to a string comparison.

**Reasoning:**

Even if a string comparison was less performant than compiling and executing a regex. This is not a performance-oriented scenario by any stretch of the imagination. Readability, discovery, and modifyability should be of a higher priority than performance in that case.