### PR TITLE
Emit event on filtered.

### DIFF
--- a/src/modules/Dropdown/Dropdown.jsx
+++ b/src/modules/Dropdown/Dropdown.jsx
@@ -318,7 +318,8 @@ export default {
     filteredOptions() {
       this.updateSelectedIndex();
     },
-    filter() {
+    filter(val) {
+      this.$emit('filtered', val);
       if (this.search) {
         this.resizeInput();
       }


### PR DESCRIPTION
Emit event on filtered, so parent can listen when filter changed.

I believe this event is important, since we can't implement network search functionality without this (except with some additional `hacks`).