### PR TITLE
Removed vertical menu from element classes

### DIFF
--- a/src/modules/Sidebar/Sidebar.jsx
+++ b/src/modules/Sidebar/Sidebar.jsx
@@ -29,7 +29,7 @@ export default {
     return (
       <ElementType
         {...this.getChildPropsAndListeners()}
-        class={`ui sidebar vertical menu ${this.direction} ${this.width} ${this.animation || ''}${this.visible ? ' visible' : ''}${this.animating ? ' animating' : ''}`}
+        class={`ui sidebar ${this.direction} ${this.width} ${this.animation || ''}${this.visible ? ' visible' : ''}${this.animating ? ' animating' : ''}`}
       >
         {this.$slots.default}
       </ElementType>


### PR DESCRIPTION
Hi,

Both classes `vertical` and `menu` should not be hard coded for the sui-sidebar element. I propose to delete them because this has an impact on the children elements display.
And 'menu' support can be added with additional class attribute...

m431m
