### PR TITLE
Nuxt module plugins are changed to full paths in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ Usage:
 ```js
 {
   modules: [
-    'semantic-ui-vue/nuxt', // includes styles from semantic-ui-css
-    ['semantic-ui-vue/nuxt', {css: false}] // if you have your own semantic-ui styles
+    '@/node_modules/semantic-ui-vue/nuxt', // includes styles from semantic-ui-css
+    ['@/node_modules/semantic-ui-vue/nuxt', {css: false}] // if you have your own semantic-ui styles
   ]
 }
 ```


### PR DESCRIPTION
NPM package names are not enough when specifying plugins in nuxt.config.js. The packages must be paths. README.md has been updated to reflect this.