### PR TITLE
WIP: Fix edit button

### DIFF
--- a/docs/examples/collections/BreadcrumbExample/Breadcrumb.example.vue
+++ b/docs/examples/collections/BreadcrumbExample/Breadcrumb.example.vue
@@ -16,7 +16,7 @@
 
 <script>
 export default {
-  name: 'BreadcrumbExample',
+  name: 'Breadcrumb',
   data() {
     return {
       sections: [

--- a/docs/examples/collections/BreadcrumbExample/BreadcrumbAngle.example.vue
+++ b/docs/examples/collections/BreadcrumbExample/BreadcrumbAngle.example.vue
@@ -16,7 +16,7 @@
 
 <script>
 export default {
-  name: 'BreadcrumbExampleAngle',
+  name: 'BreadcrumbAngle',
   data() {
     return {
       sections: [

--- a/docs/examples/collections/BreadcrumbExample/Divider.example.vue
+++ b/docs/examples/collections/BreadcrumbExample/Divider.example.vue
@@ -12,6 +12,6 @@
 
 <script>
 export default {
-  name: 'DividerExample',
+  name: 'Divider',
 };
 </script>

--- a/docs/examples/collections/BreadcrumbExample/DividerArrow.example.vue
+++ b/docs/examples/collections/BreadcrumbExample/DividerArrow.example.vue
@@ -12,6 +12,6 @@
 
 <script>
 export default {
-  name: 'DividerArrowExample',
+  name: 'DividerArrow',
 };
 </script>

--- a/docs/examples/collections/BreadcrumbExample/Link.example.vue
+++ b/docs/examples/collections/BreadcrumbExample/Link.example.vue
@@ -15,6 +15,6 @@
 
 <script>
 export default {
-  name: 'LinkExample',
+  name: 'Link',
 };
 </script>

--- a/docs/examples/collections/BreadcrumbExample/Section.example.vue
+++ b/docs/examples/collections/BreadcrumbExample/Section.example.vue
@@ -10,6 +10,6 @@
 
 <script>
 export default {
-  name: 'LinkExample',
+  name: 'Section',
 };
 </script>

--- a/docs/examples/collections/FormExample/Form.example.vue
+++ b/docs/examples/collections/FormExample/Form.example.vue
@@ -17,6 +17,6 @@
 
 <script>
 export default {
-  name: 'FormExample',
+  name: 'Form',
 };
 </script>

--- a/docs/examples/collections/GridExample/Celled.example.vue
+++ b/docs/examples/collections/GridExample/Celled.example.vue
@@ -24,6 +24,6 @@
 
 <script>
 export default {
-  name: 'CelledExample',
+  name: 'Celled',
 };
 </script>

--- a/docs/examples/collections/GridExample/Columns.example.vue
+++ b/docs/examples/collections/GridExample/Columns.example.vue
@@ -22,6 +22,6 @@
 
 <script>
 export default {
-  name: 'ColumnsExample',
+  name: 'Columns',
 };
 </script>

--- a/docs/examples/collections/GridExample/Divided.example.vue
+++ b/docs/examples/collections/GridExample/Divided.example.vue
@@ -10,6 +10,6 @@
 
 <script>
 export default {
-  name: 'DividedExample',
+  name: 'Divided',
 };
 </script>

--- a/docs/examples/collections/GridExample/Grid.example.vue
+++ b/docs/examples/collections/GridExample/Grid.example.vue
@@ -8,7 +8,7 @@
 
 <script>
 export default {
-  name: 'GridExample',
+  name: 'Grid',
   data() {
     return { columns: [...new Array(16)] };
   },

--- a/docs/examples/collections/GridExample/InternallyCelled.example.vue
+++ b/docs/examples/collections/GridExample/InternallyCelled.example.vue
@@ -28,6 +28,6 @@
 
 <script>
 export default {
-  name: 'InternallyCelledExample',
+  name: 'InternallyCelled',
 };
 </script>

--- a/docs/examples/collections/GridExample/Rows.example.vue
+++ b/docs/examples/collections/GridExample/Rows.example.vue
@@ -25,7 +25,7 @@
 
 <script>
 export default {
-  name: 'RowsExample',
+  name: 'Rows',
 };
 </script>
 

--- a/docs/examples/collections/GridExample/Stretched.example.vue
+++ b/docs/examples/collections/GridExample/Stretched.example.vue
@@ -19,6 +19,6 @@
 
 <script>
 export default {
-  name: 'StretchedExample',
+  name: 'Stretched',
 };
 </script>

--- a/docs/examples/collections/GridExample/VerticallyDivided.example.vue
+++ b/docs/examples/collections/GridExample/VerticallyDivided.example.vue
@@ -24,6 +24,6 @@
 
 <script>
 export default {
-  name: 'VerticallyDividedExample',
+  name: 'VerticallyDivided',
 };
 </script>

--- a/docs/examples/collections/MenuExample/Menu.example.vue
+++ b/docs/examples/collections/MenuExample/Menu.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'MenuExample',
+  name: 'Menu',
 };
 </script>

--- a/docs/examples/collections/MenuExample/PointingMenu.example.vue
+++ b/docs/examples/collections/MenuExample/PointingMenu.example.vue
@@ -24,7 +24,7 @@
 
 <script>
 export default {
-  name: 'PointingMenuExample',
+  name: 'PointingMenu',
   data() {
     return {
       active: 'Home',

--- a/docs/examples/collections/MenuExample/PointingSecondaryMenu.example.vue
+++ b/docs/examples/collections/MenuExample/PointingSecondaryMenu.example.vue
@@ -27,7 +27,7 @@
 
 <script>
 export default {
-  name: 'PointingMenuSecondaryExample',
+  name: 'PointingSecondaryMenu',
   data() {
     return {
       active: 'Home',

--- a/docs/examples/collections/MenuExample/SecondaryMenu.example.vue
+++ b/docs/examples/collections/MenuExample/SecondaryMenu.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'SecondaryMenuExample',
+  name: 'SecondaryMenu',
 };
 </script>

--- a/docs/examples/collections/MenuExample/TabularMenu.example.vue
+++ b/docs/examples/collections/MenuExample/TabularMenu.example.vue
@@ -13,7 +13,7 @@
 
 <script>
 export default {
-  name: 'TabularMenuExample',
+  name: 'TabularMenu',
   data() {
     return {
       items: ['Bio', 'Photos'],

--- a/docs/examples/collections/MenuExample/TabularMenuBottom.example.vue
+++ b/docs/examples/collections/MenuExample/TabularMenuBottom.example.vue
@@ -31,7 +31,7 @@
 
 <script>
 export default {
-  name: 'TabularMenuBottomExample',
+  name: 'TabularMenuBottom',
   data() {
     return {
       items: ['Active Project', 'Project #2', 'Project #3'],

--- a/docs/examples/collections/MenuExample/TabularMenuLeft.example.vue
+++ b/docs/examples/collections/MenuExample/TabularMenuLeft.example.vue
@@ -23,7 +23,7 @@
 
 <script>
 export default {
-  name: 'TabularMenuExample',
+  name: 'TabularMenuLeft',
   data() {
     return {
       items: ['Bio', 'Pics', 'Companies', 'Links'],

--- a/docs/examples/collections/MenuExample/TabularMenuRight.example.vue
+++ b/docs/examples/collections/MenuExample/TabularMenuRight.example.vue
@@ -23,7 +23,7 @@
 
 <script>
 export default {
-  name: 'TabularMenuExample',
+  name: 'TabularMenuRight',
   data() {
     return {
       items: ['Bio', 'Pics', 'Companies', 'Links'],

--- a/docs/examples/collections/MenuExample/TextMenu.example.vue
+++ b/docs/examples/collections/MenuExample/TextMenu.example.vue
@@ -14,7 +14,7 @@
 
 <script>
 export default {
-  name: 'TextMenuExample',
+  name: 'TextMenu',
   data() {
     return {
       items: ['Closest', 'Most Comments', 'Most Popular'],

--- a/docs/examples/collections/MenuExample/TopAttachedMenu.example.vue
+++ b/docs/examples/collections/MenuExample/TopAttachedMenu.example.vue
@@ -36,6 +36,6 @@
 
 <script>
 export default {
-  name: 'MenuExample',
+  name: 'TopAttachedMenu',
 };
 </script>

--- a/docs/examples/collections/MessageExample/DismissableBlock.example.vue
+++ b/docs/examples/collections/MessageExample/DismissableBlock.example.vue
@@ -17,7 +17,7 @@
 
 <script>
 export default {
-  name: 'DismissableBlockExample',
+  name: 'DismissableBlock',
   data() {
     return { visible: true };
   },

--- a/docs/examples/collections/MessageExample/Hidden.example.vue
+++ b/docs/examples/collections/MessageExample/Hidden.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'HiddenMessageExample',
+  name: 'Hidden',
 };
 </script>

--- a/docs/examples/collections/MessageExample/IconMessage.example.vue
+++ b/docs/examples/collections/MessageExample/IconMessage.example.vue
@@ -18,6 +18,6 @@
 
 <script>
 export default {
-  name: 'IconMessageExample',
+  name: 'IconMessage',
 };
 </script>

--- a/docs/examples/collections/MessageExample/ListMessage.example.vue
+++ b/docs/examples/collections/MessageExample/ListMessage.example.vue
@@ -18,7 +18,7 @@
 
 <script>
 export default {
-  name: 'MessageListExample',
+  name: 'ListMessage',
   data() {
     return {
       list: [

--- a/docs/examples/collections/MessageExample/Message.example.vue
+++ b/docs/examples/collections/MessageExample/Message.example.vue
@@ -19,6 +19,6 @@
 
 <script>
 export default {
-  name: 'MessageExample',
+  name: 'Message',
 };
 </script>

--- a/docs/examples/collections/MessageExample/Visible.example.vue
+++ b/docs/examples/collections/MessageExample/Visible.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'VisibleMessageExample',
+  name: 'Visible',
 };
 </script>

--- a/docs/examples/collections/TableExample/Table.example.vue
+++ b/docs/examples/collections/TableExample/Table.example.vue
@@ -51,6 +51,6 @@
 
 <script>
 export default {
-  name: 'TableExample',
+  name: 'Table',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableActive.example.vue
+++ b/docs/examples/collections/TableExample/TableActive.example.vue
@@ -34,6 +34,6 @@
 
 <script>
 export default {
-  name: 'TableActiveExample',
+  name: 'TableActive',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableAvatar.example.vue
+++ b/docs/examples/collections/TableExample/TableAvatar.example.vue
@@ -70,6 +70,6 @@
 
 <script>
 export default {
-  name: 'TableAvatarExample',
+  name: 'TableAvatar',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableBasic.example.vue
+++ b/docs/examples/collections/TableExample/TableBasic.example.vue
@@ -29,6 +29,6 @@
 
 <script>
 export default {
-  name: 'TableBasicExample',
+  name: 'TableBasic',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableBasicVery.example.vue
+++ b/docs/examples/collections/TableExample/TableBasicVery.example.vue
@@ -29,6 +29,6 @@
 
 <script>
 export default {
-  name: 'TableBasicVeryExample',
+  name: 'TableBasicVery',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableCelled.example.vue
+++ b/docs/examples/collections/TableExample/TableCelled.example.vue
@@ -34,6 +34,6 @@
 
 <script>
 export default {
-  name: 'TableCelledExample',
+  name: 'TableCelled',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableCollapsing.example.vue
+++ b/docs/examples/collections/TableExample/TableCollapsing.example.vue
@@ -34,6 +34,6 @@
 
 <script>
 export default {
-  name: 'TableActiveExample',
+  name: 'TableCollapsing',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableCollapsingCell.example.vue
+++ b/docs/examples/collections/TableExample/TableCollapsingCell.example.vue
@@ -31,6 +31,6 @@
 
 <script>
 export default {
-  name: 'TableCollapsingCellExample',
+  name: 'TableCollapsingCell',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableColored.example.vue
+++ b/docs/examples/collections/TableExample/TableColored.example.vue
@@ -257,6 +257,6 @@
 
 <script>
 export default {
-  name: 'TableColoredExample',
+  name: 'TableColored',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableColoredInverted.example.vue
+++ b/docs/examples/collections/TableExample/TableColoredInverted.example.vue
@@ -278,6 +278,6 @@
 
 <script>
 export default {
-  name: 'TableColoredExample',
+  name: 'TableColoredInverted',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableColumnCount.example.vue
+++ b/docs/examples/collections/TableExample/TableColumnCount.example.vue
@@ -44,6 +44,6 @@
 
 <script>
 export default {
-  name: 'TableColumnCountExample',
+  name: 'TableColumnCount',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableColumnWidth.example.vue
+++ b/docs/examples/collections/TableExample/TableColumnWidth.example.vue
@@ -29,6 +29,6 @@
 
 <script>
 export default {
-  name: 'TableColumnWidthExample',
+  name: 'TableColumnWidth',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableCompact.example.vue
+++ b/docs/examples/collections/TableExample/TableCompact.example.vue
@@ -54,6 +54,6 @@
 
 <script>
   export default {
-    name: 'TableCompactExample',
+    name: 'TableCompact',
   };
 </script>

--- a/docs/examples/collections/TableExample/TableCompactVery.example.vue
+++ b/docs/examples/collections/TableExample/TableCompactVery.example.vue
@@ -63,6 +63,6 @@
 
 <script>
   export default {
-    name: 'TableCompactVeryExample',
+    name: 'TableCompactVery',
   };
 </script>

--- a/docs/examples/collections/TableExample/TableDefinition.example.vue
+++ b/docs/examples/collections/TableExample/TableDefinition.example.vue
@@ -24,6 +24,6 @@
 
 <script>
 export default {
-  name: 'TableDefinitionExample',
+  name: 'TableDefinition',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableDisabled.example.vue
+++ b/docs/examples/collections/TableExample/TableDisabled.example.vue
@@ -34,6 +34,6 @@
 
 <script>
 export default {
-  name: 'TableWarningExample',
+  name: 'TableDisabled',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableError.example.vue
+++ b/docs/examples/collections/TableExample/TableError.example.vue
@@ -37,6 +37,6 @@
 
 <script>
 export default {
-  name: 'TableErrorExample',
+  name: 'TableError',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableFixed.example.vue
+++ b/docs/examples/collections/TableExample/TableFixed.example.vue
@@ -38,6 +38,6 @@
 
 <script>
 export default {
-  name: 'TableFixedExample',
+  name: 'TableFixed',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableFixedSingleLine.example.vue
+++ b/docs/examples/collections/TableExample/TableFixedSingleLine.example.vue
@@ -31,6 +31,6 @@
 
 <script>
 export default {
-  name: 'TableFixedSingleLineExample',
+  name: 'TableFixedSingleLine',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableFullWidth.example.vue
+++ b/docs/examples/collections/TableExample/TableFullWidth.example.vue
@@ -63,6 +63,6 @@
 
 <script>
 export default {
-  name: 'TableFullWidthExample',
+  name: 'TableFullWidth',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableGit.example.vue
+++ b/docs/examples/collections/TableExample/TableGit.example.vue
@@ -48,6 +48,6 @@
 
 <script>
 export default {
-  name: 'SuiTableGitExample',
+  name: 'TableGit',
 };
 </script>

--- a/docs/examples/collections/TableExample/TablePadded.example.vue
+++ b/docs/examples/collections/TableExample/TablePadded.example.vue
@@ -29,6 +29,6 @@
 
 <script>
 export default {
-  name: 'TablePaddedExample',
+  name: 'TablePadded',
 };
 </script>

--- a/docs/examples/collections/TableExample/TablePaddedVery.example.vue
+++ b/docs/examples/collections/TableExample/TablePaddedVery.example.vue
@@ -29,6 +29,6 @@
 
 <script>
 export default {
-  name: 'TablePaddedVeryExample',
+  name: 'TablePaddedVery',
 };
 </script>

--- a/docs/examples/collections/TableExample/TablePositiveNegative.example.vue
+++ b/docs/examples/collections/TableExample/TablePositiveNegative.example.vue
@@ -40,6 +40,6 @@
 
 <script>
 export default {
-  name: 'TablePositiveNegativeExample',
+  name: 'TablePositiveNegative',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableRating.example.vue
+++ b/docs/examples/collections/TableExample/TableRating.example.vue
@@ -53,6 +53,6 @@
 
 <script>
 export default {
-  name: 'TableRatingExample',
+  name: 'TableRating',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableSelectableCell.example.vue
+++ b/docs/examples/collections/TableExample/TableSelectableCell.example.vue
@@ -56,6 +56,6 @@
 
 <script>
 export default {
-  name: 'TableSelectableCellExample',
+  name: 'TableSelectableCell',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableSelectableRow.example.vue
+++ b/docs/examples/collections/TableExample/TableSelectableRow.example.vue
@@ -44,6 +44,6 @@
 
 <script>
 export default {
-  name: 'TableSelectableRowExample',
+  name: 'TableSelectableRow',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableSelectableRowInverted.example.vue
+++ b/docs/examples/collections/TableExample/TableSelectableRowInverted.example.vue
@@ -29,6 +29,6 @@
 
 <script>
 export default {
-  name: 'TableSelectableRowInvertedExample',
+  name: 'TableSelectableRowInverted',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableSingleLine.example.vue
+++ b/docs/examples/collections/TableExample/TableSingleLine.example.vue
@@ -33,6 +33,6 @@
 
 <script>
 export default {
-  name: 'TableLineExample',
+  name: 'TableSingleLine',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableSizeLarge.example.vue
+++ b/docs/examples/collections/TableExample/TableSizeLarge.example.vue
@@ -34,6 +34,6 @@
 
 <script>
   export default {
-    name: 'TableSizeLargeExample',
+    name: 'TableSizeLarge',
   };
 </script>

--- a/docs/examples/collections/TableExample/TableSizeSmall.example.vue
+++ b/docs/examples/collections/TableExample/TableSizeSmall.example.vue
@@ -34,6 +34,6 @@
 
 <script>
   export default {
-    name: 'TableSizeSmallExample',
+    name: 'TableSizeSmall',
   };
 </script>

--- a/docs/examples/collections/TableExample/TableStacking.example.vue
+++ b/docs/examples/collections/TableExample/TableStacking.example.vue
@@ -57,6 +57,6 @@
 
 <script>
 export default {
-  name: 'TableStackingExample',
+  name: 'TableStacking',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableStriped.example.vue
+++ b/docs/examples/collections/TableExample/TableStriped.example.vue
@@ -63,6 +63,6 @@
 
 <script>
 export default {
-  name: 'TableStripedExample',
+  name: 'TableStriped',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableTextAlignment.example.vue
+++ b/docs/examples/collections/TableExample/TableTextAlignment.example.vue
@@ -29,6 +29,6 @@
 
 <script>
 export default {
-  name: 'TableVerticalAlignmentExample',
+  name: 'TableTextAlignment',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableVerticalAlignment.example.vue
+++ b/docs/examples/collections/TableExample/TableVerticalAlignment.example.vue
@@ -32,6 +32,6 @@
 
 <script>
 export default {
-  name: 'TableVerticalAlignmentExample',
+  name: 'TableVerticalAlignment',
 };
 </script>

--- a/docs/examples/collections/TableExample/TableWarning.example.vue
+++ b/docs/examples/collections/TableExample/TableWarning.example.vue
@@ -40,6 +40,6 @@
 
 <script>
 export default {
-  name: 'TableWarningExample',
+  name: 'TableWarning',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Active.example.vue
+++ b/docs/examples/elements/ButtonExample/Active.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'ButtonActiveExample',
+  name: 'Active',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Animated.example.vue
+++ b/docs/examples/elements/ButtonExample/Animated.example.vue
@@ -27,6 +27,6 @@
 
 <script>
 export default {
-  name: 'ButtonAnimatedExample',
+  name: 'Animated',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Attached.example.vue
+++ b/docs/examples/elements/ButtonExample/Attached.example.vue
@@ -10,6 +10,6 @@
 
 <script>
 export default {
-  name: 'ButtonAttachedExample',
+  name: 'Attached',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/AttachedGroup.example.vue
+++ b/docs/examples/elements/ButtonExample/AttachedGroup.example.vue
@@ -16,6 +16,6 @@
 
 <script>
 export default {
-  name: 'ButtonAttachedExample',
+  name: 'AttachedGroup',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/AttachedHorizontally.example.vue
+++ b/docs/examples/elements/ButtonExample/AttachedHorizontally.example.vue
@@ -7,6 +7,6 @@
 
 <script>
 export default {
-  name: 'ButtonAttachedHorizontallyExample',
+  name: 'AttachedHorizontally',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Basic.example.vue
+++ b/docs/examples/elements/ButtonExample/Basic.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'ButtonBasicExample',
+  name: 'Basic',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Basic2.example.vue
+++ b/docs/examples/elements/ButtonExample/Basic2.example.vue
@@ -9,6 +9,6 @@
 
 <script>
 export default {
-  name: 'ButtonBasic2Example',
+  name: 'Basic2',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Basic3.example.vue
+++ b/docs/examples/elements/ButtonExample/Basic3.example.vue
@@ -18,6 +18,6 @@
 
 <script>
 export default {
-  name: 'ButtonBasicExample',
+  name: 'Basic3',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Button.example.vue
+++ b/docs/examples/elements/ButtonExample/Button.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'ButtonExample',
+  name: 'Button',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Buttons.example.vue
+++ b/docs/examples/elements/ButtonExample/Buttons.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'ButtonsExample',
+  name: 'Buttons',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/ButtonsBasic.example.vue
+++ b/docs/examples/elements/ButtonExample/ButtonsBasic.example.vue
@@ -16,6 +16,6 @@
 
 <script>
 export default {
-  name: 'ButtonsBasicExample',
+  name: 'ButtonsBasic',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/ButtonsBasicColored.example.vue
+++ b/docs/examples/elements/ButtonExample/ButtonsBasicColored.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'ButtonsBasicColoredExample',
+  name: 'ButtonsBasicColored',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/ButtonsColored.example.vue
+++ b/docs/examples/elements/ButtonExample/ButtonsColored.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'ButtonsColoredExample',
+  name: 'ButtonsColored',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/ButtonsEqualWidth.example.vue
+++ b/docs/examples/elements/ButtonExample/ButtonsEqualWidth.example.vue
@@ -17,6 +17,6 @@
 
 <script>
 export default {
-  name: 'ButtonsEqualWidthExample',
+  name: 'ButtonsEqualWidth',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/ButtonsIcon.example.vue
+++ b/docs/examples/elements/ButtonExample/ButtonsIcon.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'ButtonsIconExample',
+  name: 'ButtonsIcon',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/ButtonsIconLabeled.example.vue
+++ b/docs/examples/elements/ButtonExample/ButtonsIconLabeled.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'ButtonsIconLabeledExample',
+  name: 'ButtonsIconLabeled',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/ButtonsMixed.example.vue
+++ b/docs/examples/elements/ButtonExample/ButtonsMixed.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'ButtonsMixedExample',
+  name: 'ButtonsMixed',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/ButtonsSizes.example.vue
+++ b/docs/examples/elements/ButtonExample/ButtonsSizes.example.vue
@@ -23,6 +23,6 @@
 
 <script>
 export default {
-  name: 'ButtonsSizesExample',
+  name: 'ButtonsSizes',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/ButtonsVertical.example.vue
+++ b/docs/examples/elements/ButtonExample/ButtonsVertical.example.vue
@@ -9,6 +9,6 @@
 
 <script>
 export default {
-  name: 'ButtonsVerticalExample',
+  name: 'ButtonsVertical',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Circular.example.vue
+++ b/docs/examples/elements/ButtonExample/Circular.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'ButtonCircularExample',
+  name: 'Circular',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/CircularSocial.example.vue
+++ b/docs/examples/elements/ButtonExample/CircularSocial.example.vue
@@ -9,6 +9,6 @@
 
 <script>
 export default {
-  name: 'ButtonCircularSocialExample',
+  name: 'CircularSocial',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Colored.example.vue
+++ b/docs/examples/elements/ButtonExample/Colored.example.vue
@@ -18,6 +18,6 @@
 
 <script>
 export default {
-  name: 'ButtonColoredExample',
+  name: 'Colored',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Compact.example.vue
+++ b/docs/examples/elements/ButtonExample/Compact.example.vue
@@ -12,6 +12,6 @@
 
 <script>
 export default {
-  name: 'ButtonCompactExample',
+  name: 'Compact',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Conditional.example.vue
+++ b/docs/examples/elements/ButtonExample/Conditional.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'ButtonsConditionalExample',
+  name: 'Conditional',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Conditional2.example.vue
+++ b/docs/examples/elements/ButtonExample/Conditional2.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'ButtonsConditionalCustomTextExample',
+  name: 'Conditional2',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Disabled.example.vue
+++ b/docs/examples/elements/ButtonExample/Disabled.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'ButtonDisabledExample',
+  name: 'Disabled',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Emphasis.example.vue
+++ b/docs/examples/elements/ButtonExample/Emphasis.example.vue
@@ -7,6 +7,6 @@
 
 <script>
 export default {
-  name: 'ButtonEmphasisExample',
+  name: 'Emphasis',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Floated.example.vue
+++ b/docs/examples/elements/ButtonExample/Floated.example.vue
@@ -7,6 +7,6 @@
 
 <script>
 export default {
-  name: 'ButtonFloatedExample',
+  name: 'Floated',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Fluid.example.vue
+++ b/docs/examples/elements/ButtonExample/Fluid.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'ButtonFluidExample',
+  name: 'Fluid',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Group.example.vue
+++ b/docs/examples/elements/ButtonExample/Group.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'ButtonsGroupExample',
+  name: 'Group',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Icon.example.vue
+++ b/docs/examples/elements/ButtonExample/Icon.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'ButtonIconExample',
+  name: 'Icon',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/IconButtons.example.vue
+++ b/docs/examples/elements/ButtonExample/IconButtons.example.vue
@@ -16,6 +16,6 @@
 
 <script>
 export default {
-  name: 'IconButtonsExample',
+  name: 'IconButtons',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Inverted.example.vue
+++ b/docs/examples/elements/ButtonExample/Inverted.example.vue
@@ -18,6 +18,6 @@
 
 <script>
 export default {
-  name: 'ButtonInvertedExample',
+  name: 'Inverted',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Inverted2.example.vue
+++ b/docs/examples/elements/ButtonExample/Inverted2.example.vue
@@ -18,6 +18,6 @@
 
 <script>
 export default {
-  name: 'ButtonInvertedDarkExample',
+  name: 'Inverted2',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Labeled.example.vue
+++ b/docs/examples/elements/ButtonExample/Labeled.example.vue
@@ -23,6 +23,6 @@
 
 <script>
 export default {
-  name: 'ButtonLabeledExample',
+  name: 'Labeled',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Labeled2.example.vue
+++ b/docs/examples/elements/ButtonExample/Labeled2.example.vue
@@ -33,6 +33,6 @@
 
 <script>
 export default {
-  name: 'ButtonLabeledBasicExample',
+  name: 'Labeled2',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/LabeledIcon.example.vue
+++ b/docs/examples/elements/ButtonExample/LabeledIcon.example.vue
@@ -7,6 +7,6 @@
 
 <script>
 export default {
-  name: 'ButtonLabeledIconExample',
+  name: 'LabeledIcon',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Loading.example.vue
+++ b/docs/examples/elements/ButtonExample/Loading.example.vue
@@ -9,6 +9,6 @@
 
 <script>
 export default {
-  name: 'ButtonLoadingExample',
+  name: 'Loading',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Negative.example.vue
+++ b/docs/examples/elements/ButtonExample/Negative.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'ButtonNegativeExample',
+  name: 'Negative',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Positive.example.vue
+++ b/docs/examples/elements/ButtonExample/Positive.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'ButtonPositiveExample',
+  name: 'Positive',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Size.example.vue
+++ b/docs/examples/elements/ButtonExample/Size.example.vue
@@ -13,6 +13,6 @@
 
 <script>
 export default {
-  name: 'ButtonSizeExample',
+  name: 'Size',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Social.example.vue
+++ b/docs/examples/elements/ButtonExample/Social.example.vue
@@ -12,6 +12,6 @@
 
 <script>
 export default {
-  name: 'ButtonSocialExample',
+  name: 'Social',
 };
 </script>

--- a/docs/examples/elements/ButtonExample/Toggle.example.vue
+++ b/docs/examples/elements/ButtonExample/Toggle.example.vue
@@ -9,7 +9,7 @@
 
 <script>
 export default {
-  name: 'ButtonToggleExample',
+  name: 'Toggle',
   data: () => ({
     isActive: false,
   }),

--- a/docs/examples/elements/ContainerExample/Container.example.vue
+++ b/docs/examples/elements/ContainerExample/Container.example.vue
@@ -20,6 +20,6 @@
 
 <script>
 export default {
-  name: 'ContainerExample',
+  name: 'Container',
 };
 </script>

--- a/docs/examples/elements/ContainerExample/Fluid.example.vue
+++ b/docs/examples/elements/ContainerExample/Fluid.example.vue
@@ -25,6 +25,6 @@
 
 <script>
 export default {
-  name: 'FluidExample',
+  name: 'Fluid',
 };
 </script>

--- a/docs/examples/elements/ContainerExample/TextAlignment.example.vue
+++ b/docs/examples/elements/ContainerExample/TextAlignment.example.vue
@@ -49,6 +49,6 @@
 
 <script>
 export default {
-  name: 'TextAlignmentExample',
+  name: 'TextAlignment',
 };
 </script>

--- a/docs/examples/elements/ContainerExample/TextContainer.example.vue
+++ b/docs/examples/elements/ContainerExample/TextContainer.example.vue
@@ -36,6 +36,6 @@
 
 <script>
 export default {
-  name: 'TextContainerExample',
+  name: 'TextContainer',
 };
 </script>

--- a/docs/examples/elements/DividerExample/ClearingDivider.example.vue
+++ b/docs/examples/elements/DividerExample/ClearingDivider.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'SectionDivider',
+  name: 'ClearingDivider',
 };
 </script>

--- a/docs/examples/elements/DividerExample/Divider.example.vue
+++ b/docs/examples/elements/DividerExample/Divider.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'DividerExample',
+  name: 'Divider',
 };
 </script>

--- a/docs/examples/elements/DividerExample/FittedDivider.example.vue
+++ b/docs/examples/elements/DividerExample/FittedDivider.example.vue
@@ -12,6 +12,6 @@
 
 <script>
 export default {
-  name: 'InvertedDivider',
+  name: 'FittedDivider',
 };
 </script>

--- a/docs/examples/elements/DividerExample/HorizontalDivider.example.vue
+++ b/docs/examples/elements/DividerExample/HorizontalDivider.example.vue
@@ -17,6 +17,6 @@
 
 <script>
 export default {
-  name: 'HorizontalDividerExample',
+  name: 'HorizontalDivider',
 };
 </script>

--- a/docs/examples/elements/DividerExample/HorizontalDivider2.example.vue
+++ b/docs/examples/elements/DividerExample/HorizontalDivider2.example.vue
@@ -45,6 +45,6 @@
 
 <script>
 export default {
-  name: 'HorizontalDivider2Example',
+  name: 'HorizontalDivider2',
 };
 </script>

--- a/docs/examples/elements/FlagExample/Flag.example.vue
+++ b/docs/examples/elements/FlagExample/Flag.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'FlagExample',
+  name: 'Flag',
 };
 </script>

--- a/docs/examples/elements/HeaderExample/Attached.example.vue
+++ b/docs/examples/elements/HeaderExample/Attached.example.vue
@@ -12,5 +12,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Attached' };
 </script>

--- a/docs/examples/elements/HeaderExample/Block.example.vue
+++ b/docs/examples/elements/HeaderExample/Block.example.vue
@@ -5,5 +5,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Block' };
 </script>

--- a/docs/examples/elements/HeaderExample/Colored.example.vue
+++ b/docs/examples/elements/HeaderExample/Colored.example.vue
@@ -40,5 +40,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Colored' };
 </script>

--- a/docs/examples/elements/HeaderExample/Disabled.example.vue
+++ b/docs/examples/elements/HeaderExample/Disabled.example.vue
@@ -5,5 +5,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Disabled' };
 </script>

--- a/docs/examples/elements/HeaderExample/Dividing.example.vue
+++ b/docs/examples/elements/HeaderExample/Dividing.example.vue
@@ -5,5 +5,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Dividing' };
 </script>

--- a/docs/examples/elements/HeaderExample/Floating.example.vue
+++ b/docs/examples/elements/HeaderExample/Floating.example.vue
@@ -10,5 +10,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Floating' };
 </script>

--- a/docs/examples/elements/HeaderExample/Icon.example.vue
+++ b/docs/examples/elements/HeaderExample/Icon.example.vue
@@ -6,5 +6,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Icon' };
 </script>

--- a/docs/examples/elements/HeaderExample/IconFriends.example.vue
+++ b/docs/examples/elements/HeaderExample/IconFriends.example.vue
@@ -9,5 +9,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'IconFriends' };
 </script>

--- a/docs/examples/elements/HeaderExample/IconSubheader.example.vue
+++ b/docs/examples/elements/HeaderExample/IconSubheader.example.vue
@@ -9,5 +9,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'IconSubheader' };
 </script>

--- a/docs/examples/elements/HeaderExample/ImageAvatar.example.vue
+++ b/docs/examples/elements/HeaderExample/ImageAvatar.example.vue
@@ -5,5 +5,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'ImageAvatar' };
 </script>

--- a/docs/examples/elements/HeaderExample/ImageLearnMore.example.vue
+++ b/docs/examples/elements/HeaderExample/ImageLearnMore.example.vue
@@ -3,5 +3,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'ImageLearnMore' };
 </script>

--- a/docs/examples/elements/HeaderExample/Inverted.example.vue
+++ b/docs/examples/elements/HeaderExample/Inverted.example.vue
@@ -40,5 +40,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Inverted' };
 </script>

--- a/docs/examples/elements/HeaderExample/SubHeader.example.vue
+++ b/docs/examples/elements/HeaderExample/SubHeader.example.vue
@@ -6,5 +6,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'SubHeader' };
 </script>

--- a/docs/examples/elements/HeaderExample/SubheaderContent.example.vue
+++ b/docs/examples/elements/HeaderExample/SubheaderContent.example.vue
@@ -8,5 +8,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'SubheaderContent' };
 </script>

--- a/docs/examples/elements/HeaderExample/TextAlignment.example.vue
+++ b/docs/examples/elements/HeaderExample/TextAlignment.example.vue
@@ -16,5 +16,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'TextAlignment' };
 </script>

--- a/docs/examples/elements/IconExample/Bordered.example.vue
+++ b/docs/examples/elements/IconExample/Bordered.example.vue
@@ -18,6 +18,6 @@
 
 <script>
 export default {
-  name: 'BorderedExample',
+  name: 'Bordered',
 };
 </script>

--- a/docs/examples/elements/IconExample/Circular.example.vue
+++ b/docs/examples/elements/IconExample/Circular.example.vue
@@ -18,6 +18,6 @@
 
 <script>
 export default {
-  name: 'CircularExample',
+  name: 'Circular',
 };
 </script>

--- a/docs/examples/elements/IconExample/Colored.example.vue
+++ b/docs/examples/elements/IconExample/Colored.example.vue
@@ -18,6 +18,6 @@
 
 <script>
 export default {
-  name: 'ColoredExample',
+  name: 'Colored',
 };
 </script>

--- a/docs/examples/elements/IconExample/Disabled.example.vue
+++ b/docs/examples/elements/IconExample/Disabled.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'DisabledExample',
+  name: 'Disabled',
 };
 </script>

--- a/docs/examples/elements/IconExample/Fitted.example.vue
+++ b/docs/examples/elements/IconExample/Fitted.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'FittedExample',
+  name: 'Fitted',
 };
 </script>

--- a/docs/examples/elements/IconExample/Flipped.example.vue
+++ b/docs/examples/elements/IconExample/Flipped.example.vue
@@ -7,6 +7,6 @@
 
 <script>
 export default {
-  name: 'FlippedExample',
+  name: 'Flipped',
 };
 </script>

--- a/docs/examples/elements/IconExample/IconGroup2.example.vue
+++ b/docs/examples/elements/IconExample/IconGroup2.example.vue
@@ -9,6 +9,6 @@
 
 <script>
 export default {
-  name: 'IconGroup',
+  name: 'IconGroup2',
 };
 </script>

--- a/docs/examples/elements/IconExample/Inverted.example.vue
+++ b/docs/examples/elements/IconExample/Inverted.example.vue
@@ -20,6 +20,6 @@
 
 <script>
 export default {
-  name: 'InvertedExample',
+  name: 'Inverted',
 };
 </script>

--- a/docs/examples/elements/IconExample/Link.example.vue
+++ b/docs/examples/elements/IconExample/Link.example.vue
@@ -7,6 +7,6 @@
 
 <script>
 export default {
-  name: 'LinkExample',
+  name: 'Link',
 };
 </script>

--- a/docs/examples/elements/IconExample/Loading.example.vue
+++ b/docs/examples/elements/IconExample/Loading.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'LoadingExample',
+  name: 'Loading',
 };
 </script>

--- a/docs/examples/elements/IconExample/Rotated.example.vue
+++ b/docs/examples/elements/IconExample/Rotated.example.vue
@@ -7,6 +7,6 @@
 
 <script>
 export default {
-  name: 'RotatedExample',
+  name: 'Rotated',
 };
 </script>

--- a/docs/examples/elements/IconExample/Size.example.vue
+++ b/docs/examples/elements/IconExample/Size.example.vue
@@ -14,6 +14,6 @@
 
 <script>
 export default {
-  name: 'SizeExample',
+  name: 'Size',
 };
 </script>

--- a/docs/examples/elements/ImageExample/Avatar.example.vue
+++ b/docs/examples/elements/ImageExample/Avatar.example.vue
@@ -6,5 +6,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Avatar' };
 </script>

--- a/docs/examples/elements/ImageExample/Bordered.example.vue
+++ b/docs/examples/elements/ImageExample/Bordered.example.vue
@@ -3,5 +3,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Bordered' };
 </script>

--- a/docs/examples/elements/ImageExample/Centered.example.vue
+++ b/docs/examples/elements/ImageExample/Centered.example.vue
@@ -23,5 +23,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Centered' };
 </script>

--- a/docs/examples/elements/ImageExample/Circular.example.vue
+++ b/docs/examples/elements/ImageExample/Circular.example.vue
@@ -4,5 +4,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Circular' };
 </script>

--- a/docs/examples/elements/ImageExample/Disabled.example.vue
+++ b/docs/examples/elements/ImageExample/Disabled.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'DisabledExample',
+  name: 'Disabled',
 };
 </script>

--- a/docs/examples/elements/ImageExample/Floated.example.vue
+++ b/docs/examples/elements/ImageExample/Floated.example.vue
@@ -23,5 +23,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Floated' };
 </script>

--- a/docs/examples/elements/ImageExample/Fluid.example.vue
+++ b/docs/examples/elements/ImageExample/Fluid.example.vue
@@ -3,5 +3,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Fluid' };
 </script>

--- a/docs/examples/elements/ImageExample/Hidden.example.vue
+++ b/docs/examples/elements/ImageExample/Hidden.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'HiddenExample',
+  name: 'Hidden',
 };
 </script>

--- a/docs/examples/elements/ImageExample/Image.example.vue
+++ b/docs/examples/elements/ImageExample/Image.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'ImageExample',
+  name: 'Image',
 };
 </script>

--- a/docs/examples/elements/ImageExample/ImageLink.example.vue
+++ b/docs/examples/elements/ImageExample/ImageLink.example.vue
@@ -10,6 +10,6 @@
 
 <script>
 export default {
-  name: 'ImageLinkExample',
+  name: 'ImageLink',
 };
 </script>

--- a/docs/examples/elements/ImageExample/Rounded.example.vue
+++ b/docs/examples/elements/ImageExample/Rounded.example.vue
@@ -3,5 +3,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Rounded' };
 </script>

--- a/docs/examples/elements/InputExample/Disabled.example.vue
+++ b/docs/examples/elements/InputExample/Disabled.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'InputDisabledExample',
+  name: 'Disabled',
 };
 </script>

--- a/docs/examples/elements/InputExample/Focus.example.vue
+++ b/docs/examples/elements/InputExample/Focus.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'FocusExample',
+  name: 'Focus',
 };
 </script>

--- a/docs/examples/elements/InputExample/Icon.example.vue
+++ b/docs/examples/elements/InputExample/Icon.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'IconExample',
+  name: 'Icon',
 };
 </script>

--- a/docs/examples/elements/InputExample/Input.example.vue
+++ b/docs/examples/elements/InputExample/Input.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'InputExample',
+  name: 'Input',
 };
 </script>

--- a/docs/examples/elements/InputExample/Loading.example.vue
+++ b/docs/examples/elements/InputExample/Loading.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'LoadingExample',
+  name: 'Loading',
 };
 </script>

--- a/docs/examples/elements/InputExample/Loading2.example.vue
+++ b/docs/examples/elements/InputExample/Loading2.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'Loading2Example',
+  name: 'Loading2',
 };
 </script>

--- a/docs/examples/elements/InputExample/Size.example.vue
+++ b/docs/examples/elements/InputExample/Size.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'SizeExample',
+  name: 'Size',
 };
 </script>

--- a/docs/examples/elements/InputExample/Size2.example.vue
+++ b/docs/examples/elements/InputExample/Size2.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'Size2Example',
+  name: 'Size2',
 };
 </script>

--- a/docs/examples/elements/InputExample/Size3.example.vue
+++ b/docs/examples/elements/InputExample/Size3.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'Size3Example',
+  name: 'Size3',
 };
 </script>

--- a/docs/examples/elements/InputExample/Size4.example.vue
+++ b/docs/examples/elements/InputExample/Size4.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'Size4Example',
+  name: 'Size4',
 };
 </script>

--- a/docs/examples/elements/InputExample/Size5.example.vue
+++ b/docs/examples/elements/InputExample/Size5.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'Size5Example',
+  name: 'Size5',
 };
 </script>

--- a/docs/examples/elements/InputExample/Size6.example.vue
+++ b/docs/examples/elements/InputExample/Size6.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'Size6Example',
+  name: 'Size6',
 };
 </script>

--- a/docs/examples/elements/LabelExample/Attached.example.vue
+++ b/docs/examples/elements/LabelExample/Attached.example.vue
@@ -45,5 +45,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Attached' };
 </script>

--- a/docs/examples/elements/LabelExample/Basic.example.vue
+++ b/docs/examples/elements/LabelExample/Basic.example.vue
@@ -25,5 +25,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Basic' };
 </script>

--- a/docs/examples/elements/LabelExample/ContentImage.example.vue
+++ b/docs/examples/elements/LabelExample/ContentImage.example.vue
@@ -12,5 +12,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'ContentImage' };
 </script>

--- a/docs/examples/elements/LabelExample/Corner.example.vue
+++ b/docs/examples/elements/LabelExample/Corner.example.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Corner' };
 </script>
 
 <style lang="css">

--- a/docs/examples/elements/LabelExample/Detail.example.vue
+++ b/docs/examples/elements/LabelExample/Detail.example.vue
@@ -6,5 +6,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Detail' };
 </script>

--- a/docs/examples/elements/LabelExample/Floating.example.vue
+++ b/docs/examples/elements/LabelExample/Floating.example.vue
@@ -16,6 +16,6 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Floating' };
 </script>
 

--- a/docs/examples/elements/LabelExample/Horizontal.example.vue
+++ b/docs/examples/elements/LabelExample/Horizontal.example.vue
@@ -26,6 +26,6 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Horizontal' };
 </script>
 

--- a/docs/examples/elements/LabelExample/Icon.example.vue
+++ b/docs/examples/elements/LabelExample/Icon.example.vue
@@ -12,5 +12,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Icon' };
 </script>

--- a/docs/examples/elements/LabelExample/Image.example.vue
+++ b/docs/examples/elements/LabelExample/Image.example.vue
@@ -17,6 +17,6 @@
 
 <script>
 export default {
-  name: 'ImageExample',
+  name: 'Image',
 };
 </script>

--- a/docs/examples/elements/LabelExample/Image2.example.vue
+++ b/docs/examples/elements/LabelExample/Image2.example.vue
@@ -20,6 +20,6 @@
 
 <script>
 export default {
-  name: 'Image2Example',
+  name: 'Image2',
 };
 </script>

--- a/docs/examples/elements/LabelExample/Image3.example.vue
+++ b/docs/examples/elements/LabelExample/Image3.example.vue
@@ -20,6 +20,6 @@
 
 <script>
 export default {
-  name: 'Image3Example',
+  name: 'Image3',
 };
 </script>

--- a/docs/examples/elements/LabelExample/Label.example.vue
+++ b/docs/examples/elements/LabelExample/Label.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'LabelExample',
+  name: 'Label',
 };
 </script>

--- a/docs/examples/elements/LabelExample/Link.example.vue
+++ b/docs/examples/elements/LabelExample/Link.example.vue
@@ -5,5 +5,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Link' };
 </script>

--- a/docs/examples/elements/LabelExample/LinkText.example.vue
+++ b/docs/examples/elements/LabelExample/LinkText.example.vue
@@ -7,5 +7,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'LinkText' };
 </script>

--- a/docs/examples/elements/LabelExample/Pointing.example.vue
+++ b/docs/examples/elements/LabelExample/Pointing.example.vue
@@ -27,6 +27,6 @@
 
 <script>
 export default {
-  name: 'PointingExample',
+  name: 'Pointing',
 };
 </script>

--- a/docs/examples/elements/LabelExample/PointingRed.example.vue
+++ b/docs/examples/elements/LabelExample/PointingRed.example.vue
@@ -29,6 +29,6 @@
 
 <script>
 export default {
-  name: 'PointingExample',
+  name: 'PointingRed',
 };
 </script>

--- a/docs/examples/elements/LabelExample/Ribbon.example.vue
+++ b/docs/examples/elements/LabelExample/Ribbon.example.vue
@@ -35,5 +35,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Ribbon' };
 </script>

--- a/docs/examples/elements/LabelExample/RibbonImage.example.vue
+++ b/docs/examples/elements/LabelExample/RibbonImage.example.vue
@@ -37,6 +37,6 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'RibbonImage' };
 </script>
 

--- a/docs/examples/elements/LabelExample/Tag.example.vue
+++ b/docs/examples/elements/LabelExample/Tag.example.vue
@@ -13,5 +13,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Tag' };
 </script>

--- a/docs/examples/elements/ListExample/Bulleted.example.vue
+++ b/docs/examples/elements/ListExample/Bulleted.example.vue
@@ -15,5 +15,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Bulleted' };
 </script>

--- a/docs/examples/elements/ListExample/BulletedHorizontal.example.vue
+++ b/docs/examples/elements/ListExample/BulletedHorizontal.example.vue
@@ -7,5 +7,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'BulletedHorizontal' };
 </script>

--- a/docs/examples/elements/ListExample/Description.example.vue
+++ b/docs/examples/elements/ListExample/Description.example.vue
@@ -41,5 +41,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Description' };
 </script>

--- a/docs/examples/elements/ListExample/Header.example.vue
+++ b/docs/examples/elements/ListExample/Header.example.vue
@@ -20,5 +20,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Header' };
 </script>

--- a/docs/examples/elements/ListExample/Icon.example.vue
+++ b/docs/examples/elements/ListExample/Icon.example.vue
@@ -26,5 +26,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Icon' };
 </script>

--- a/docs/examples/elements/ListExample/Image.example.vue
+++ b/docs/examples/elements/ListExample/Image.example.vue
@@ -63,5 +63,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Image' };
 </script>

--- a/docs/examples/elements/ListExample/Item.example.vue
+++ b/docs/examples/elements/ListExample/Item.example.vue
@@ -7,5 +7,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Item' };
 </script>

--- a/docs/examples/elements/ListExample/Link.example.vue
+++ b/docs/examples/elements/ListExample/Link.example.vue
@@ -8,5 +8,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Link' };
 </script>

--- a/docs/examples/elements/ListExample/LinkContent.example.vue
+++ b/docs/examples/elements/ListExample/LinkContent.example.vue
@@ -7,5 +7,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'LinkContent' };
 </script>

--- a/docs/examples/elements/ListExample/LinkDescription.example.vue
+++ b/docs/examples/elements/ListExample/LinkDescription.example.vue
@@ -16,5 +16,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'LinkDescription' };
 </script>

--- a/docs/examples/elements/ListExample/List.example.vue
+++ b/docs/examples/elements/ListExample/List.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'ListExample',
+  name: 'List',
 };
 </script>

--- a/docs/examples/elements/ListExample/ListDivided.example.vue
+++ b/docs/examples/elements/ListExample/ListDivided.example.vue
@@ -26,6 +26,6 @@
 
 <script>
 export default {
-  name: 'ListDividedExample',
+  name: 'ListDivided',
 };
 </script>

--- a/docs/examples/elements/ListExample/ListIcon.example.vue
+++ b/docs/examples/elements/ListExample/ListIcon.example.vue
@@ -26,6 +26,6 @@
 
 <script>
 export default {
-  name: 'ListIconExample',
+  name: 'ListIcon',
 };
 </script>

--- a/docs/examples/elements/ListExample/ListInverted.example.vue
+++ b/docs/examples/elements/ListExample/ListInverted.example.vue
@@ -26,6 +26,6 @@
 
 <script>
 export default {
-  name: 'ListInvertedExample',
+  name: 'ListInverted',
 };
 </script>

--- a/docs/examples/elements/ListExample/ListShorthand.example.vue
+++ b/docs/examples/elements/ListExample/ListShorthand.example.vue
@@ -4,7 +4,7 @@
 
 <script>
 export default {
-  name: 'ListShorthandExample',
+  name: 'ListShorthand',
   data() {
     return {
       items: ['Apples', 'Pears', 'Oranges'],

--- a/docs/examples/elements/ListExample/ListTree.example.vue
+++ b/docs/examples/elements/ListExample/ListTree.example.vue
@@ -76,6 +76,6 @@
 
 <script>
 export default {
-  name: 'ListShorthandExample',
+  name: 'ListTree',
 };
 </script>

--- a/docs/examples/elements/ListExample/Ordered.example.vue
+++ b/docs/examples/elements/ListExample/Ordered.example.vue
@@ -15,5 +15,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Ordered' };
 </script>

--- a/docs/examples/elements/ListExample/OrderedNumber.example.vue
+++ b/docs/examples/elements/ListExample/OrderedNumber.example.vue
@@ -15,5 +15,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'OrderedNumber' };
 </script>

--- a/docs/examples/elements/LoaderExample/Active.example.vue
+++ b/docs/examples/elements/LoaderExample/Active.example.vue
@@ -7,6 +7,6 @@
 
 <script>
 export default {
-  name: 'ActiveExample',
+  name: 'Active',
 };
 </script>

--- a/docs/examples/elements/LoaderExample/Disabled.example.vue
+++ b/docs/examples/elements/LoaderExample/Disabled.example.vue
@@ -7,6 +7,6 @@
 
 <script>
 export default {
-  name: 'DisabledExample',
+  name: 'Disabled',
 };
 </script>

--- a/docs/examples/elements/LoaderExample/Indeterminate.example.vue
+++ b/docs/examples/elements/LoaderExample/Indeterminate.example.vue
@@ -10,6 +10,6 @@
 
 <script>
 export default {
-  name: 'IndeterminateExample',
+  name: 'Indeterminate',
 };
 </script>

--- a/docs/examples/elements/LoaderExample/Inline.example.vue
+++ b/docs/examples/elements/LoaderExample/Inline.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'InlineExample',
+  name: 'Inline',
 };
 </script>

--- a/docs/examples/elements/LoaderExample/InlineCentered.example.vue
+++ b/docs/examples/elements/LoaderExample/InlineCentered.example.vue
@@ -4,6 +4,6 @@
 
 <script>
 export default {
-  name: 'InlineCenteredExample',
+  name: 'InlineCentered',
 };
 </script>

--- a/docs/examples/elements/LoaderExample/Inverted.example.vue
+++ b/docs/examples/elements/LoaderExample/Inverted.example.vue
@@ -10,6 +10,6 @@
 
 <script>
 export default {
-  name: 'InvertedExample',
+  name: 'Inverted',
 };
 </script>

--- a/docs/examples/elements/LoaderExample/Inverted2.example.vue
+++ b/docs/examples/elements/LoaderExample/Inverted2.example.vue
@@ -11,6 +11,6 @@
 
 <script>
 export default {
-  name: 'Inverted2Example',
+  name: 'Inverted2',
 };
 </script>

--- a/docs/examples/elements/LoaderExample/Loader.example.vue
+++ b/docs/examples/elements/LoaderExample/Loader.example.vue
@@ -17,6 +17,6 @@
 
 <script>
 export default {
-  name: 'LoaderExample',
+  name: 'Loader',
 };
 </script>

--- a/docs/examples/elements/LoaderExample/SizeBig.example.vue
+++ b/docs/examples/elements/LoaderExample/SizeBig.example.vue
@@ -9,6 +9,6 @@
 
 <script>
 export default {
-  name: 'SizeBigExample',
+  name: 'SizeBig',
 };
 </script>

--- a/docs/examples/elements/LoaderExample/SizeHuge.example.vue
+++ b/docs/examples/elements/LoaderExample/SizeHuge.example.vue
@@ -9,6 +9,6 @@
 
 <script>
 export default {
-  name: 'SizeHugeExample',
+  name: 'SizeHuge',
 };
 </script>

--- a/docs/examples/elements/LoaderExample/SizeLarge.example.vue
+++ b/docs/examples/elements/LoaderExample/SizeLarge.example.vue
@@ -9,6 +9,6 @@
 
 <script>
 export default {
-  name: 'SizeLargeExample',
+  name: 'SizeLarge',
 };
 </script>

--- a/docs/examples/elements/LoaderExample/SizeMassive.example.vue
+++ b/docs/examples/elements/LoaderExample/SizeMassive.example.vue
@@ -9,6 +9,6 @@
 
 <script>
 export default {
-  name: 'SizeMassiveExample',
+  name: 'SizeMassive',
 };
 </script>

--- a/docs/examples/elements/LoaderExample/SizeMedium.example.vue
+++ b/docs/examples/elements/LoaderExample/SizeMedium.example.vue
@@ -9,6 +9,6 @@
 
 <script>
 export default {
-  name: 'SizeMediumExample',
+  name: 'SizeMedium',
 };
 </script>

--- a/docs/examples/elements/LoaderExample/SizeMini.example.vue
+++ b/docs/examples/elements/LoaderExample/SizeMini.example.vue
@@ -9,6 +9,6 @@
 
 <script>
 export default {
-  name: 'SizeMiniExample',
+  name: 'SizeMini',
 };
 </script>

--- a/docs/examples/elements/LoaderExample/SizeSmall.example.vue
+++ b/docs/examples/elements/LoaderExample/SizeSmall.example.vue
@@ -9,6 +9,6 @@
 
 <script>
 export default {
-  name: 'SizeSmallExample',
+  name: 'SizeSmall',
 };
 </script>

--- a/docs/examples/elements/LoaderExample/SizeTiny.example.vue
+++ b/docs/examples/elements/LoaderExample/SizeTiny.example.vue
@@ -9,6 +9,6 @@
 
 <script>
 export default {
-  name: 'SizeTinyExample',
+  name: 'SizeTiny',
 };
 </script>

--- a/docs/examples/elements/LoaderExample/TextLoader.example.vue
+++ b/docs/examples/elements/LoaderExample/TextLoader.example.vue
@@ -10,6 +10,6 @@
 
 <script>
 export default {
-  name: 'TextLoaderExample',
+  name: 'TextLoader',
 };
 </script>

--- a/docs/examples/elements/LoaderExample/TextLoaderInverted.example.vue
+++ b/docs/examples/elements/LoaderExample/TextLoaderInverted.example.vue
@@ -10,6 +10,6 @@
 
 <script>
 export default {
-  name: 'TextLoaderInvertedExample',
+  name: 'TextLoaderInverted',
 };
 </script>

--- a/docs/examples/elements/RailExample/Attached.example.vue
+++ b/docs/examples/elements/RailExample/Attached.example.vue
@@ -19,6 +19,6 @@
 
 <script>
 export default {
-  name: 'RailExample',
+  name: 'Attached',
 };
 </script>

--- a/docs/examples/elements/RailExample/Dividing.example.vue
+++ b/docs/examples/elements/RailExample/Dividing.example.vue
@@ -19,6 +19,6 @@
 
 <script>
 export default {
-  name: 'RailExample',
+  name: 'Dividing',
 };
 </script>

--- a/docs/examples/elements/RailExample/Internal.example.vue
+++ b/docs/examples/elements/RailExample/Internal.example.vue
@@ -12,7 +12,7 @@
 
 <script>
 export default {
-  name: 'InternalExample',
+  name: 'Internal',
 };
 </script>
 

--- a/docs/examples/elements/RailExample/Rail.example.vue
+++ b/docs/examples/elements/RailExample/Rail.example.vue
@@ -19,6 +19,6 @@
 
 <script>
 export default {
-  name: 'RailExample',
+  name: 'Rail',
 };
 </script>

--- a/docs/examples/elements/RevealExample/Active.example.vue
+++ b/docs/examples/elements/RevealExample/Active.example.vue
@@ -10,5 +10,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Active' };
 </script>

--- a/docs/examples/elements/RevealExample/Disabled.example.vue
+++ b/docs/examples/elements/RevealExample/Disabled.example.vue
@@ -10,5 +10,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Disabled' };
 </script>

--- a/docs/examples/elements/RevealExample/Fade.example.vue
+++ b/docs/examples/elements/RevealExample/Fade.example.vue
@@ -10,5 +10,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Fade' };
 </script>

--- a/docs/examples/elements/RevealExample/HiddenContent.example.vue
+++ b/docs/examples/elements/RevealExample/HiddenContent.example.vue
@@ -10,5 +10,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'HiddenContent' };
 </script>

--- a/docs/examples/elements/RevealExample/Instant.example.vue
+++ b/docs/examples/elements/RevealExample/Instant.example.vue
@@ -10,5 +10,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Instant' };
 </script>

--- a/docs/examples/elements/RevealExample/MoveDown.example.vue
+++ b/docs/examples/elements/RevealExample/MoveDown.example.vue
@@ -10,5 +10,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'MoveDown' };
 </script>

--- a/docs/examples/elements/RevealExample/MoveLeft.example.vue
+++ b/docs/examples/elements/RevealExample/MoveLeft.example.vue
@@ -10,5 +10,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'MoveLeft' };
 </script>

--- a/docs/examples/elements/RevealExample/MoveRight.example.vue
+++ b/docs/examples/elements/RevealExample/MoveRight.example.vue
@@ -10,5 +10,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'MoveRight' };
 </script>

--- a/docs/examples/elements/RevealExample/MoveUp.example.vue
+++ b/docs/examples/elements/RevealExample/MoveUp.example.vue
@@ -10,5 +10,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'MoveUp' };
 </script>

--- a/docs/examples/elements/RevealExample/RotateLeft.example.vue
+++ b/docs/examples/elements/RevealExample/RotateLeft.example.vue
@@ -10,5 +10,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'RotateLeft' };
 </script>

--- a/docs/examples/elements/RevealExample/RotateRight.example.vue
+++ b/docs/examples/elements/RevealExample/RotateRight.example.vue
@@ -10,5 +10,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'RotateRight' };
 </script>

--- a/docs/examples/elements/RevealExample/VisibleContent.example.vue
+++ b/docs/examples/elements/RevealExample/VisibleContent.example.vue
@@ -10,5 +10,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'VisibleContent' };
 </script>

--- a/docs/examples/elements/SegmentExample/Attached.example.vue
+++ b/docs/examples/elements/SegmentExample/Attached.example.vue
@@ -14,6 +14,6 @@
 
 <script>
 export default {
-  name: 'AttachedExample',
+  name: 'Attached',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Attached2.example.vue
+++ b/docs/examples/elements/SegmentExample/Attached2.example.vue
@@ -23,6 +23,6 @@
 
 <script>
 export default {
-  name: 'Attached2Example',
+  name: 'Attached2',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Basic.example.vue
+++ b/docs/examples/elements/SegmentExample/Basic.example.vue
@@ -12,6 +12,6 @@
 
 <script>
 export default {
-  name: 'BasicExample',
+  name: 'Basic',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Circular.example.vue
+++ b/docs/examples/elements/SegmentExample/Circular.example.vue
@@ -17,7 +17,7 @@
 
 <script>
 export default {
-  name: 'CircularExample',
+  name: 'Circular',
 };
 </script>
 

--- a/docs/examples/elements/SegmentExample/Clearing.example.vue
+++ b/docs/examples/elements/SegmentExample/Clearing.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'ClearingExample',
+  name: 'Clearing',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Color.example.vue
+++ b/docs/examples/elements/SegmentExample/Color.example.vue
@@ -18,6 +18,6 @@
 
 <script>
 export default {
-  name: 'ColorExample',
+  name: 'Color',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Color2.example.vue
+++ b/docs/examples/elements/SegmentExample/Color2.example.vue
@@ -18,6 +18,6 @@
 
 <script>
 export default {
-  name: 'Color2Example',
+  name: 'Color2',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Compact.example.vue
+++ b/docs/examples/elements/SegmentExample/Compact.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'CompactExample',
+  name: 'Compact',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Disabled.example.vue
+++ b/docs/examples/elements/SegmentExample/Disabled.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'DisabledExample',
+  name: 'Disabled',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Emphasis.example.vue
+++ b/docs/examples/elements/SegmentExample/Emphasis.example.vue
@@ -14,6 +14,6 @@
 
 <script>
 export default {
-  name: 'EmphasisExample',
+  name: 'Emphasis',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Emphasis2.example.vue
+++ b/docs/examples/elements/SegmentExample/Emphasis2.example.vue
@@ -14,6 +14,6 @@
 
 <script>
 export default {
-  name: 'Emphasis2Example',
+  name: 'Emphasis2',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Emphasis3.example.vue
+++ b/docs/examples/elements/SegmentExample/Emphasis3.example.vue
@@ -14,6 +14,6 @@
 
 <script>
 export default {
-  name: 'Emphasis3Example',
+  name: 'Emphasis3',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Floated.example.vue
+++ b/docs/examples/elements/SegmentExample/Floated.example.vue
@@ -11,6 +11,6 @@
 
 <script>
 export default {
-  name: 'FloatedExample',
+  name: 'Floated',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/HorizontalSegments.example.vue
+++ b/docs/examples/elements/SegmentExample/HorizontalSegments.example.vue
@@ -14,6 +14,6 @@
 
 <script>
 export default {
-  name: 'HorizontalSegmentsExample',
+  name: 'HorizontalSegments',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Inverted.example.vue
+++ b/docs/examples/elements/SegmentExample/Inverted.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'InvertedExample',
+  name: 'Inverted',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Loading.example.vue
+++ b/docs/examples/elements/SegmentExample/Loading.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'LoadingExample',
+  name: 'Loading',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/NestedSegments.example.vue
+++ b/docs/examples/elements/SegmentExample/NestedSegments.example.vue
@@ -27,6 +27,6 @@
 
 <script>
 export default {
-  name: 'NestedSegmentsExample',
+  name: 'NestedSegments',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Padded.example.vue
+++ b/docs/examples/elements/SegmentExample/Padded.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'PaddedExample',
+  name: 'Padded',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Padded2.example.vue
+++ b/docs/examples/elements/SegmentExample/Padded2.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'Padded2Example',
+  name: 'Padded2',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Piled.example.vue
+++ b/docs/examples/elements/SegmentExample/Piled.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'PiledExample',
+  name: 'Piled',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/PiledSegments.example.vue
+++ b/docs/examples/elements/SegmentExample/PiledSegments.example.vue
@@ -14,6 +14,6 @@
 
 <script>
 export default {
-  name: 'PiledSegmentsExample',
+  name: 'PiledSegments',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Raised.example.vue
+++ b/docs/examples/elements/SegmentExample/Raised.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'RaisedExample',
+  name: 'Raised',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/RaisedSegments.example.vue
+++ b/docs/examples/elements/SegmentExample/RaisedSegments.example.vue
@@ -14,6 +14,6 @@
 
 <script>
 export default {
-  name: 'RaisedSegmentsExample',
+  name: 'RaisedSegments',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Segment.example.vue
+++ b/docs/examples/elements/SegmentExample/Segment.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'SegmentExample',
+  name: 'Segment',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Segments.example.vue
+++ b/docs/examples/elements/SegmentExample/Segments.example.vue
@@ -14,6 +14,6 @@
 
 <script>
 export default {
-  name: 'SegmentsExample',
+  name: 'Segments',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Stacked.example.vue
+++ b/docs/examples/elements/SegmentExample/Stacked.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'StackedExample',
+  name: 'Stacked',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/StackedSegments.example.vue
+++ b/docs/examples/elements/SegmentExample/StackedSegments.example.vue
@@ -14,6 +14,6 @@
 
 <script>
 export default {
-  name: 'StackedSegmentsExample',
+  name: 'StackedSegments',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/StackedTall.example.vue
+++ b/docs/examples/elements/SegmentExample/StackedTall.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'StackedTallExample',
+  name: 'StackedTall',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/TextAlign.example.vue
+++ b/docs/examples/elements/SegmentExample/TextAlign.example.vue
@@ -14,6 +14,6 @@
 
 <script>
 export default {
-  name: 'TextAlignExample',
+  name: 'TextAlign',
 };
 </script>

--- a/docs/examples/elements/SegmentExample/Vertical.example.vue
+++ b/docs/examples/elements/SegmentExample/Vertical.example.vue
@@ -14,6 +14,6 @@
 
 <script>
 export default {
-  name: 'VerticalExample',
+  name: 'Vertical',
 };
 </script>

--- a/docs/examples/elements/StepExample/Active.example.vue
+++ b/docs/examples/elements/StepExample/Active.example.vue
@@ -11,6 +11,6 @@
 
 <script>
 export default {
-  name: 'ActiveExample',
+  name: 'Active',
 };
 </script>

--- a/docs/examples/elements/StepExample/Attached.example.vue
+++ b/docs/examples/elements/StepExample/Attached.example.vue
@@ -40,6 +40,6 @@
 
 <script>
 export default {
-  name: 'AttachedExample',
+  name: 'Attached',
 };
 </script>

--- a/docs/examples/elements/StepExample/Completed.example.vue
+++ b/docs/examples/elements/StepExample/Completed.example.vue
@@ -11,6 +11,6 @@
 
 <script>
 export default {
-  name: 'CompletedExample',
+  name: 'Completed',
 };
 </script>

--- a/docs/examples/elements/StepExample/Completed2.example.vue
+++ b/docs/examples/elements/StepExample/Completed2.example.vue
@@ -10,6 +10,6 @@
 
 <script>
 export default {
-  name: 'Completed2Example',
+  name: 'Completed2',
 };
 </script>

--- a/docs/examples/elements/StepExample/Description.example.vue
+++ b/docs/examples/elements/StepExample/Description.example.vue
@@ -9,6 +9,6 @@
 
 <script>
 export default {
-  name: 'DescriptionExample',
+  name: 'Description',
 };
 </script>

--- a/docs/examples/elements/StepExample/Description2.example.vue
+++ b/docs/examples/elements/StepExample/Description2.example.vue
@@ -11,6 +11,6 @@
 
 <script>
 export default {
-  name: 'Description2Example',
+  name: 'Description2',
 };
 </script>

--- a/docs/examples/elements/StepExample/Disabled.example.vue
+++ b/docs/examples/elements/StepExample/Disabled.example.vue
@@ -11,6 +11,6 @@
 
 <script>
 export default {
-  name: 'DisabledExample',
+  name: 'Disabled',
 };
 </script>

--- a/docs/examples/elements/StepExample/EvenlyDivided.example.vue
+++ b/docs/examples/elements/StepExample/EvenlyDivided.example.vue
@@ -16,6 +16,6 @@
 
 <script>
 export default {
-  name: 'EvenlyDividedExample',
+  name: 'EvenlyDivided',
 };
 </script>

--- a/docs/examples/elements/StepExample/EvenlyDivided2.example.vue
+++ b/docs/examples/elements/StepExample/EvenlyDivided2.example.vue
@@ -13,6 +13,6 @@
 
 <script>
 export default {
-  name: 'EvenlyDivided2Example',
+  name: 'EvenlyDivided2',
 };
 </script>

--- a/docs/examples/elements/StepExample/Fluid.example.vue
+++ b/docs/examples/elements/StepExample/Fluid.example.vue
@@ -22,6 +22,6 @@
 
 <script>
 export default {
-  name: 'FluidExample',
+  name: 'Fluid',
 };
 </script>

--- a/docs/examples/elements/StepExample/Icon.example.vue
+++ b/docs/examples/elements/StepExample/Icon.example.vue
@@ -10,6 +10,6 @@
 
 <script>
 export default {
-  name: 'IconExample',
+  name: 'Icon',
 };
 </script>

--- a/docs/examples/elements/StepExample/Link.example.vue
+++ b/docs/examples/elements/StepExample/Link.example.vue
@@ -17,6 +17,6 @@
 
 <script>
 export default {
-  name: 'LinkExample',
+  name: 'Link',
 };
 </script>

--- a/docs/examples/elements/StepExample/Link2.example.vue
+++ b/docs/examples/elements/StepExample/Link2.example.vue
@@ -17,6 +17,6 @@
 
 <script>
 export default {
-  name: 'Link2Example',
+  name: 'Link2',
 };
 </script>

--- a/docs/examples/elements/StepExample/Ordered.example.vue
+++ b/docs/examples/elements/StepExample/Ordered.example.vue
@@ -17,6 +17,6 @@
 
 <script>
 export default {
-  name: 'OrderedExample',
+  name: 'Ordered',
 };
 </script>

--- a/docs/examples/elements/StepExample/SizeBig.example.vue
+++ b/docs/examples/elements/StepExample/SizeBig.example.vue
@@ -12,6 +12,6 @@
 
 <script>
 export default {
-  name: 'SizeBigExample',
+  name: 'SizeBig',
 };
 </script>

--- a/docs/examples/elements/StepExample/SizeHuge.example.vue
+++ b/docs/examples/elements/StepExample/SizeHuge.example.vue
@@ -12,6 +12,6 @@
 
 <script>
 export default {
-  name: 'SizeHugeExample',
+  name: 'SizeHuge',
 };
 </script>

--- a/docs/examples/elements/StepExample/SizeLarge.example.vue
+++ b/docs/examples/elements/StepExample/SizeLarge.example.vue
@@ -12,6 +12,6 @@
 
 <script>
 export default {
-  name: 'SizeLargeExample',
+  name: 'SizeLarge',
 };
 </script>

--- a/docs/examples/elements/StepExample/SizeMassive.example.vue
+++ b/docs/examples/elements/StepExample/SizeMassive.example.vue
@@ -12,6 +12,6 @@
 
 <script>
 export default {
-  name: 'SizeMassiveExample',
+  name: 'SizeMassive',
 };
 </script>

--- a/docs/examples/elements/StepExample/SizeMini.example.vue
+++ b/docs/examples/elements/StepExample/SizeMini.example.vue
@@ -19,6 +19,6 @@
 
 <script>
 export default {
-  name: 'SizeMiniExample',
+  name: 'SizeMini',
 };
 </script>

--- a/docs/examples/elements/StepExample/SizeSmall.example.vue
+++ b/docs/examples/elements/StepExample/SizeSmall.example.vue
@@ -19,6 +19,6 @@
 
 <script>
 export default {
-  name: 'SizeSmallExample',
+  name: 'SizeSmall',
 };
 </script>

--- a/docs/examples/elements/StepExample/SizeTiny.example.vue
+++ b/docs/examples/elements/StepExample/SizeTiny.example.vue
@@ -19,6 +19,6 @@
 
 <script>
 export default {
-  name: 'SizeTinyExample',
+  name: 'SizeTiny',
 };
 </script>

--- a/docs/examples/elements/StepExample/Stackable.example.vue
+++ b/docs/examples/elements/StepExample/Stackable.example.vue
@@ -21,6 +21,6 @@
 
 <script>
 export default {
-  name: 'StackableExample',
+  name: 'Stackable',
 };
 </script>

--- a/docs/examples/elements/StepExample/Step.example.vue
+++ b/docs/examples/elements/StepExample/Step.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'StepExample',
+  name: 'Step',
 };
 </script>

--- a/docs/examples/elements/StepExample/Steps.example.vue
+++ b/docs/examples/elements/StepExample/Steps.example.vue
@@ -28,7 +28,7 @@
 
 <script>
 export default {
-  name: 'StepExample',
+  name: 'Steps',
   data() {
     return {
       steps: [

--- a/docs/examples/elements/StepExample/Unstackable.example.vue
+++ b/docs/examples/elements/StepExample/Unstackable.example.vue
@@ -21,6 +21,6 @@
 
 <script>
 export default {
-  name: 'UnStackableExample',
+  name: 'Unstackable',
 };
 </script>

--- a/docs/examples/elements/StepExample/Vertical.example.vue
+++ b/docs/examples/elements/StepExample/Vertical.example.vue
@@ -27,6 +27,6 @@
 
 <script>
 export default {
-  name: 'VerticalExample',
+  name: 'Vertical',
 };
 </script>

--- a/docs/examples/modules/AccordionExample/NestedAccordions.example.vue
+++ b/docs/examples/modules/AccordionExample/NestedAccordions.example.vue
@@ -47,6 +47,6 @@
 
 <script>
 export default {
-  name: 'NestedAccordionsExample',
+  name: 'NestedAccordions',
 };
 </script>

--- a/docs/examples/modules/CheckboxExample/CheckboxBasic.example.vue
+++ b/docs/examples/modules/CheckboxExample/CheckboxBasic.example.vue
@@ -6,7 +6,7 @@
 
 <script>
 export default {
-  name: 'CheckboxBasicExample',
+  name: 'CheckboxBasic',
 };
 </script>
 

--- a/docs/examples/modules/CheckboxExample/CheckboxDisabled.example.vue
+++ b/docs/examples/modules/CheckboxExample/CheckboxDisabled.example.vue
@@ -6,7 +6,7 @@
 
 <script>
 export default {
-  name: 'CheckboxDisabledExample',
+  name: 'CheckboxDisabled',
   data() {
     return { value: true };
   },

--- a/docs/examples/modules/CheckboxExample/CheckboxModel.example.vue
+++ b/docs/examples/modules/CheckboxExample/CheckboxModel.example.vue
@@ -7,7 +7,7 @@
 
 <script>
 export default {
-  name: 'CheckboxModelExample',
+  name: 'CheckboxModel',
   data() {
     return { value: true };
   },

--- a/docs/examples/modules/CheckboxExample/CheckboxToggle.example.vue
+++ b/docs/examples/modules/CheckboxExample/CheckboxToggle.example.vue
@@ -6,7 +6,7 @@
 
 <script>
 export default {
-  name: 'CheckboxToggleExample',
+  name: 'CheckboxToggle',
   data() {
     return { value: true };
   },

--- a/docs/examples/modules/CheckboxExample/CheckboxToggleDisabled.example.vue
+++ b/docs/examples/modules/CheckboxExample/CheckboxToggleDisabled.example.vue
@@ -10,7 +10,7 @@
 
 <script>
 export default {
-  name: 'CheckboxToggleDisabledExample',
+  name: 'CheckboxToggleDisabled',
   data() {
     return { value: true };
   },

--- a/docs/examples/modules/CheckboxExample/Radio.example.vue
+++ b/docs/examples/modules/CheckboxExample/Radio.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'RadioExample',
+  name: 'Radio',
 };
 </script>

--- a/docs/examples/modules/CheckboxExample/RadioDisabled.example.vue
+++ b/docs/examples/modules/CheckboxExample/RadioDisabled.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'RadioDisabledExample',
+  name: 'RadioDisabled',
 };
 </script>

--- a/docs/examples/modules/CheckboxExample/RadioGroup.example.vue
+++ b/docs/examples/modules/CheckboxExample/RadioGroup.example.vue
@@ -41,7 +41,7 @@
 
 <script>
 export default {
-  name: 'RadioGroupInlineExample',
+  name: 'RadioGroup',
   data() {
     return {
       value: '2',

--- a/docs/examples/modules/CheckboxExample/RadioGroupInline.example.vue
+++ b/docs/examples/modules/CheckboxExample/RadioGroupInline.example.vue
@@ -41,7 +41,7 @@
 
 <script>
 export default {
-  name: 'RadioGroupInlineExample',
+  name: 'RadioGroupInline',
   data() {
     return {
       value: '1',

--- a/docs/examples/modules/DimmerExample/Dimmer.example.vue
+++ b/docs/examples/modules/DimmerExample/Dimmer.example.vue
@@ -7,7 +7,7 @@
 
 <script>
 export default {
-  name: 'DimmerBasicExample',
+  name: 'Dimmer',
 };
 </script>
 

--- a/docs/examples/modules/DimmerExample/DimmerInverted.example.vue
+++ b/docs/examples/modules/DimmerExample/DimmerInverted.example.vue
@@ -6,7 +6,7 @@
 </template>
 <script>
 export default {
-  name: 'DimmerBasicExample',
+  name: 'DimmerInverted',
   data() {
     return { enable: true };
   },

--- a/docs/examples/modules/DropdownExample/DisabledDropdown.example.vue
+++ b/docs/examples/modules/DropdownExample/DisabledDropdown.example.vue
@@ -16,6 +16,6 @@
 
 <script>
 export default {
-  name: 'DisabledDropdownExample',
+  name: 'DisabledDropdown',
 };
 </script>

--- a/docs/examples/modules/DropdownExample/Dropdown.example.vue
+++ b/docs/examples/modules/DropdownExample/Dropdown.example.vue
@@ -16,6 +16,6 @@
 
 <script>
 export default {
-  name: 'DropdownExample',
+  name: 'Dropdown',
 };
 </script>

--- a/docs/examples/modules/DropdownExample/DropdownButton.example.vue
+++ b/docs/examples/modules/DropdownExample/DropdownButton.example.vue
@@ -25,6 +25,6 @@
 
 <script>
 export default {
-  name: 'DropdownButtonExample',
+  name: 'DropdownButton',
 };
 </script>

--- a/docs/examples/modules/DropdownExample/DropdownDirection.example.vue
+++ b/docs/examples/modules/DropdownExample/DropdownDirection.example.vue
@@ -19,6 +19,6 @@
 
 <script>
 export default {
-  name: 'DropdownDirectionExample',
+  name: 'DropdownDirection',
 };
 </script>

--- a/docs/examples/modules/DropdownExample/DropdownFloating.example.vue
+++ b/docs/examples/modules/DropdownExample/DropdownFloating.example.vue
@@ -18,6 +18,6 @@
 
 <script>
 export default {
-  name: 'DropdownFloatingExample',
+  name: 'DropdownFloating',
 };
 </script>

--- a/docs/examples/modules/DropdownExample/DropdownPointing.example.vue
+++ b/docs/examples/modules/DropdownExample/DropdownPointing.example.vue
@@ -17,6 +17,6 @@
 
 <script>
 export default {
-  name: 'DropdownPointingExample',
+  name: 'DropdownPointing',
 };
 </script>

--- a/docs/examples/modules/DropdownExample/DropdownPointingWithPosition.example.vue
+++ b/docs/examples/modules/DropdownExample/DropdownPointingWithPosition.example.vue
@@ -18,6 +18,6 @@
 
 <script>
 export default {
-  name: 'DropdownPointingWithPositionExample',
+  name: 'DropdownPointingWithPosition',
 };
 </script>

--- a/docs/examples/modules/DropdownExample/DropdownSearchInMenu.example.vue
+++ b/docs/examples/modules/DropdownExample/DropdownSearchInMenu.example.vue
@@ -16,7 +16,7 @@
 
 <script>
 export default {
-  name: 'DropdownExample',
+  name: 'DropdownSearchInMenu',
   data() {
     return {
       menuHeader: {

--- a/docs/examples/modules/DropdownExample/FriendSelection.example.vue
+++ b/docs/examples/modules/DropdownExample/FriendSelection.example.vue
@@ -10,7 +10,7 @@
 
 <script>
 export default {
-  name: 'FriendSelectionExample',
+  name: 'FriendSelection',
   data() {
     return {
       current: null,

--- a/docs/examples/modules/DropdownExample/MultipleSearchSelection.example.vue
+++ b/docs/examples/modules/DropdownExample/MultipleSearchSelection.example.vue
@@ -12,7 +12,7 @@
 
 <script>
 export default {
-  name: 'MultipleSearchSelectionExample',
+  name: 'MultipleSearchSelection',
   data() {
     return {
       current: null,

--- a/docs/examples/modules/DropdownExample/MultipleSearchSelectionWithAddition.example.vue
+++ b/docs/examples/modules/DropdownExample/MultipleSearchSelectionWithAddition.example.vue
@@ -13,7 +13,7 @@
 
 <script>
 export default {
-  name: 'MultipleSearchSelectionWithAdditionExample',
+  name: 'MultipleSearchSelectionWithAddition',
   data() {
     return {
       current: null,

--- a/docs/examples/modules/DropdownExample/MultipleSelection.example.vue
+++ b/docs/examples/modules/DropdownExample/MultipleSelection.example.vue
@@ -11,7 +11,7 @@
 
 <script>
 export default {
-  name: 'MultipleSelectionExample',
+  name: 'MultipleSelection',
   data() {
     return {
       current: null,

--- a/docs/examples/modules/DropdownExample/SearchDropdown.example.vue
+++ b/docs/examples/modules/DropdownExample/SearchDropdown.example.vue
@@ -16,7 +16,7 @@
 
 <script>
 export default {
-  name: 'DropdownExample',
+  name: 'SearchDropdown',
   data() {
     return {
       current: null,

--- a/docs/examples/modules/DropdownExample/SearchSelection.example.vue
+++ b/docs/examples/modules/DropdownExample/SearchSelection.example.vue
@@ -11,7 +11,7 @@
 
 <script>
 export default {
-  name: 'SearchSelectionExample',
+  name: 'SearchSelection',
   data() {
     return {
       current: null,

--- a/docs/examples/modules/DropdownExample/SearchSelectionWithoutFlag.example.vue
+++ b/docs/examples/modules/DropdownExample/SearchSelectionWithoutFlag.example.vue
@@ -10,7 +10,7 @@
 
 <script>
 export default {
-  name: 'SearchSelectionWithoutFlagExample',
+  name: 'SearchSelectionWithoutFlag',
   data() {
     return {
       countries: [

--- a/docs/examples/modules/DropdownExample/Selection.example.vue
+++ b/docs/examples/modules/DropdownExample/Selection.example.vue
@@ -9,7 +9,7 @@
 
 <script>
 export default {
-  name: 'SelectionExample',
+  name: 'Selection',
   data() {
     return {
       current: null,

--- a/docs/examples/modules/EmbedExample/Active.example.vue
+++ b/docs/examples/modules/EmbedExample/Active.example.vue
@@ -21,7 +21,7 @@
 
 <script>
 export default {
-  name: 'ActiveExample',
+  name: 'Active',
   data() {
     return {
       active: false,

--- a/docs/examples/modules/EmbedExample/AspectRatio.example.vue
+++ b/docs/examples/modules/EmbedExample/AspectRatio.example.vue
@@ -9,6 +9,6 @@
 
 <script>
 export default {
-  name: 'AspectRatioExample',
+  name: 'AspectRatio',
 };
 </script>

--- a/docs/examples/modules/EmbedExample/CustomContent.example.vue
+++ b/docs/examples/modules/EmbedExample/CustomContent.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'CustomContentExample',
+  name: 'CustomContent',
 };
 </script>

--- a/docs/examples/modules/EmbedExample/Iframe.example.vue
+++ b/docs/examples/modules/EmbedExample/Iframe.example.vue
@@ -18,6 +18,6 @@
 
 <script>
 export default {
-  name: 'IframeExample',
+  name: 'Iframe',
 };
 </script>

--- a/docs/examples/modules/EmbedExample/SourceSettings.example.vue
+++ b/docs/examples/modules/EmbedExample/SourceSettings.example.vue
@@ -12,6 +12,6 @@
 
 <script>
 export default {
-  name: 'SourceSettingsExample',
+  name: 'SourceSettings',
 };
 </script>

--- a/docs/examples/modules/EmbedExample/Vimeo.example.vue
+++ b/docs/examples/modules/EmbedExample/Vimeo.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'VimeoExample',
+  name: 'Vimeo',
 };
 </script>

--- a/docs/examples/modules/EmbedExample/YouTube.example.vue
+++ b/docs/examples/modules/EmbedExample/YouTube.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'YouTubeExample',
+  name: 'YouTube',
 };
 </script>

--- a/docs/examples/modules/ModalExample/Modal.example.vue
+++ b/docs/examples/modules/ModalExample/Modal.example.vue
@@ -22,7 +22,7 @@
 
 <script>
 export default {
-  name: 'ModalExample',
+  name: 'Modal',
   data() {
     return { open: false };
   },

--- a/docs/examples/modules/ModalExample/ScrollingModal.example.vue
+++ b/docs/examples/modules/ModalExample/ScrollingModal.example.vue
@@ -23,7 +23,7 @@
 
 <script>
 export default {
-  name: 'ScrollingModalExample',
+  name: 'ScrollingModal',
   data() {
     return { open: false };
   },

--- a/docs/examples/modules/PopupExample/Basic.example.vue
+++ b/docs/examples/modules/PopupExample/Basic.example.vue
@@ -5,5 +5,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Basic' };
 </script>

--- a/docs/examples/modules/PopupExample/Flowing.example.vue
+++ b/docs/examples/modules/PopupExample/Flowing.example.vue
@@ -28,5 +28,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Flowing' };
 </script>

--- a/docs/examples/modules/PopupExample/Html.example.vue
+++ b/docs/examples/modules/PopupExample/Html.example.vue
@@ -20,5 +20,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Html' };
 </script>

--- a/docs/examples/modules/PopupExample/Inverted.example.vue
+++ b/docs/examples/modules/PopupExample/Inverted.example.vue
@@ -10,5 +10,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Inverted' };
 </script>

--- a/docs/examples/modules/PopupExample/Popup.example.vue
+++ b/docs/examples/modules/PopupExample/Popup.example.vue
@@ -25,5 +25,5 @@ Vue.use(PortalVue);
 </template>
 
 <script>
-export default {};
+export default { name: 'Popup' };
 </script>

--- a/docs/examples/modules/PopupExample/Position.example.vue
+++ b/docs/examples/modules/PopupExample/Position.example.vue
@@ -122,5 +122,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Position' };
 </script>

--- a/docs/examples/modules/PopupExample/Size.example.vue
+++ b/docs/examples/modules/PopupExample/Size.example.vue
@@ -34,5 +34,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Size' };
 </script>

--- a/docs/examples/modules/PopupExample/Titled.example.vue
+++ b/docs/examples/modules/PopupExample/Titled.example.vue
@@ -18,17 +18,17 @@ export default {
     return {
       users: [
         {
-          name: 'Elliot Fu',
+          name: 'Titled',
           bio: 'Elliot has been a member since July 2012',
           avatar: 'static/images/avatar/small/elliot.jpg',
         },
         {
-          name: 'Stevie Feliciano',
+          name: 'Titled',
           bio: 'Stevie has been a member since August 2013',
           avatar: 'static/images/avatar/small/stevie.jpg',
         },
         {
-          name: 'Matt',
+          name: 'Titled',
           bio: 'Matt has been a member since July 2014',
           avatar: 'static/images/avatar/small/matt.jpg',
         },

--- a/docs/examples/modules/PopupExample/Width.example.vue
+++ b/docs/examples/modules/PopupExample/Width.example.vue
@@ -19,5 +19,5 @@
 </template>
 
 <script>
-export default {};
+export default { name: 'Width' };
 </script>

--- a/docs/examples/modules/ProgressExample/Active.example.vue
+++ b/docs/examples/modules/ProgressExample/Active.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'ActiveProgressExample',
+  name: 'Active',
 };
 </script>

--- a/docs/examples/modules/ProgressExample/Attached.example.vue
+++ b/docs/examples/modules/ProgressExample/Attached.example.vue
@@ -22,7 +22,7 @@
 
 <script>
 export default {
-  name: 'AttachedProgressExample',
+  name: 'Attached',
   data() {
     return { percent: 43 };
   },

--- a/docs/examples/modules/ProgressExample/Bar.example.vue
+++ b/docs/examples/modules/ProgressExample/Bar.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'BarProgressExample',
+  name: 'Bar',
 };
 </script>

--- a/docs/examples/modules/ProgressExample/Color.example.vue
+++ b/docs/examples/modules/ProgressExample/Color.example.vue
@@ -18,6 +18,6 @@
 
 <script>
 export default {
-  name: 'ColorProgressExample',
+  name: 'Color',
 };
 </script>

--- a/docs/examples/modules/ProgressExample/Disabled.example.vue
+++ b/docs/examples/modules/ProgressExample/Disabled.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'DisabledProgressExample',
+  name: 'Disabled',
 };
 </script>

--- a/docs/examples/modules/ProgressExample/Error.example.vue
+++ b/docs/examples/modules/ProgressExample/Error.example.vue
@@ -11,6 +11,6 @@
 
 <script>
 export default {
-  name: 'ErrorProgressExample',
+  name: 'Error',
 };
 </script>

--- a/docs/examples/modules/ProgressExample/Indicating.example.vue
+++ b/docs/examples/modules/ProgressExample/Indicating.example.vue
@@ -13,7 +13,7 @@
 
 <script>
 export default {
-  name: 'IndicatingProgressExample',
+  name: 'Indicating',
   data() {
     return { percent: 43 };
   },

--- a/docs/examples/modules/ProgressExample/Inverted.example.vue
+++ b/docs/examples/modules/ProgressExample/Inverted.example.vue
@@ -20,6 +20,6 @@
 
 <script>
 export default {
-  name: 'InvertedProgressExample',
+  name: 'Inverted',
 };
 </script>

--- a/docs/examples/modules/ProgressExample/Label.example.vue
+++ b/docs/examples/modules/ProgressExample/Label.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'LabelProgressExample',
+  name: 'Label',
 };
 </script>

--- a/docs/examples/modules/ProgressExample/Progress.example.vue
+++ b/docs/examples/modules/ProgressExample/Progress.example.vue
@@ -8,7 +8,7 @@
 
 <script>
 export default {
-  name: 'ProgressExample',
+  name: 'Progress',
   data() {
     return { percent: 17 };
   },

--- a/docs/examples/modules/ProgressExample/Size.example.vue
+++ b/docs/examples/modules/ProgressExample/Size.example.vue
@@ -13,6 +13,6 @@
 
 <script>
 export default {
-  name: 'SizeProgressExample',
+  name: 'Size',
 };
 </script>

--- a/docs/examples/modules/ProgressExample/Standard.example.vue
+++ b/docs/examples/modules/ProgressExample/Standard.example.vue
@@ -8,7 +8,7 @@
 
 <script>
 export default {
-  name: 'StandardProgressExample',
+  name: 'Standard',
   data() {
     return { percent: 10 };
   },

--- a/docs/examples/modules/ProgressExample/Success.example.vue
+++ b/docs/examples/modules/ProgressExample/Success.example.vue
@@ -11,6 +11,6 @@
 
 <script>
 export default {
-  name: 'SuccessProgressExample',
+  name: 'Success',
 };
 </script>

--- a/docs/examples/modules/ProgressExample/Warning.example.vue
+++ b/docs/examples/modules/ProgressExample/Warning.example.vue
@@ -11,6 +11,6 @@
 
 <script>
 export default {
-  name: 'WarningProgressExample',
+  name: 'Warning',
 };
 </script>

--- a/docs/examples/modules/RatingExample/Callback.example.vue
+++ b/docs/examples/modules/RatingExample/Callback.example.vue
@@ -7,7 +7,7 @@
 
 <script>
 export default {
-  name: 'CallbackExample',
+  name: 'Callback',
   data() {
     return {
       value: 1,

--- a/docs/examples/modules/RatingExample/Rating.example.vue
+++ b/docs/examples/modules/RatingExample/Rating.example.vue
@@ -6,7 +6,7 @@
 
 <script>
 export default {
-  name: 'RatingExample',
+  name: 'Rating',
   data() {
     return { value: 1 };
   },

--- a/docs/examples/modules/SearchExample/Search.example.vue
+++ b/docs/examples/modules/SearchExample/Search.example.vue
@@ -6,7 +6,7 @@
 
 <script>
 export default {
-  name: 'SearchExample',
+  name: 'Search',
   data() {
     return {
       value: null,

--- a/docs/examples/modules/SearchExample/SearchCategory.example.vue
+++ b/docs/examples/modules/SearchExample/SearchCategory.example.vue
@@ -11,7 +11,7 @@
 
 <script>
 export default {
-  name: 'SearchCategoryExample',
+  name: 'SearchCategory',
   data() {
     return {
       value: null,

--- a/docs/examples/modules/SearchExample/SearchMinCharacters.example.vue
+++ b/docs/examples/modules/SearchExample/SearchMinCharacters.example.vue
@@ -10,7 +10,7 @@
 
 <script>
     export default {
-      name: 'SearchExample',
+      name: 'SearchMinCharacters',
       data() {
         return {
           value: null,

--- a/docs/examples/modules/SearchExample/SearchStandard.example.vue
+++ b/docs/examples/modules/SearchExample/SearchStandard.example.vue
@@ -14,7 +14,7 @@
 
 <script>
 export default {
-  name: 'SearchExample',
+  name: 'SearchStandard',
   data() {
     return {
       valueBasic: null,

--- a/docs/examples/modules/SearchExample/index.js
+++ b/docs/examples/modules/SearchExample/index.js
@@ -1,6 +1,6 @@
-import SearchStandard from './Search.standard.example';
-import SearchMinCharacters from './Search.minCharacters.example';
-import SearchCategory from './Search.category.example';
+import SearchStandard from './SearchStandard.example';
+import SearchMinCharacters from './SearchMinCharacters.example';
+import SearchCategory from './SearchCategory.example';
 
 export default [
   {

--- a/docs/examples/modules/TabExample/MenuVariations/Attached.example.vue
+++ b/docs/examples/modules/TabExample/MenuVariations/Attached.example.vue
@@ -18,6 +18,6 @@
 
 <script>
   export default {
-    name: 'AttachedExample',
+    name: 'Attached',
   };
 </script>

--- a/docs/examples/modules/TabExample/MenuVariations/Borderless.example.vue
+++ b/docs/examples/modules/TabExample/MenuVariations/Borderless.example.vue
@@ -18,6 +18,6 @@
 
 <script>
   export default {
-    name: 'BorderlessExample',
+    name: 'Borderless',
   };
 </script>

--- a/docs/examples/modules/TabExample/MenuVariations/Colored.example.vue
+++ b/docs/examples/modules/TabExample/MenuVariations/Colored.example.vue
@@ -30,7 +30,7 @@
 
 <script>
   export default {
-    name: 'ColoredExample',
+    name: 'Colored',
     data: () => ({
       selectedColor: 'blue',
       colors: [

--- a/docs/examples/modules/TabExample/MenuVariations/ColoredInverted.example.vue
+++ b/docs/examples/modules/TabExample/MenuVariations/ColoredInverted.example.vue
@@ -30,7 +30,7 @@
 
 <script>
   export default {
-    name: 'ColoredExample',
+    name: 'ColoredInverted',
     data: () => ({
       selectedColor: 'blue',
       colors: [

--- a/docs/examples/modules/TabExample/MenuVariations/MenuPositionRight.example.vue
+++ b/docs/examples/modules/TabExample/MenuVariations/MenuPositionRight.example.vue
@@ -19,6 +19,6 @@
 
 <script>
   export default {
-    name: 'MenuPositionRightExample',
+    name: 'MenuPositionRight',
   };
 </script>

--- a/docs/examples/modules/TabExample/MenuVariations/NotAttached.example.vue
+++ b/docs/examples/modules/TabExample/MenuVariations/NotAttached.example.vue
@@ -18,6 +18,6 @@
 
 <script>
   export default {
-    name: 'NotAttachedExample',
+    name: 'NotAttached',
   };
 </script>

--- a/docs/examples/modules/TabExample/MenuVariations/NotTabular.example.vue
+++ b/docs/examples/modules/TabExample/MenuVariations/NotTabular.example.vue
@@ -18,6 +18,6 @@
 
 <script>
   export default {
-    name: 'NotTabularExample',
+    name: 'NotTabular',
   };
 </script>

--- a/docs/examples/modules/TabExample/MenuVariations/VerticalTabular.example.vue
+++ b/docs/examples/modules/TabExample/MenuVariations/VerticalTabular.example.vue
@@ -18,6 +18,6 @@
 
 <script>
   export default {
-    name: 'VerticalTabularExample',
+    name: 'VerticalTabular',
   };
 </script>

--- a/docs/examples/modules/TabExample/MenuVariations/VerticalTabularRight.example.vue
+++ b/docs/examples/modules/TabExample/MenuVariations/VerticalTabularRight.example.vue
@@ -18,6 +18,6 @@
 
 <script>
   export default {
-    name: 'VerticalTabularRightExample',
+    name: 'VerticalTabularRight',
   };
 </script>

--- a/docs/examples/modules/TabExample/States/Disabled.example.vue
+++ b/docs/examples/modules/TabExample/States/Disabled.example.vue
@@ -20,7 +20,7 @@
 
 <script>
   export default {
-    name: 'DisabledExample',
+    name: 'Disabled',
     data: () => ({
       disabled: true,
     }),

--- a/docs/examples/modules/TabExample/States/Loading.example.vue
+++ b/docs/examples/modules/TabExample/States/Loading.example.vue
@@ -16,6 +16,6 @@
 
 <script>
   export default {
-    name: 'LoadingExample',
+    name: 'Loading',
   };
 </script>

--- a/docs/examples/modules/TabExample/Types/Basic.example.vue
+++ b/docs/examples/modules/TabExample/Types/Basic.example.vue
@@ -39,6 +39,6 @@
 
 <script>
   export default {
-    name: 'BasicExample',
+    name: 'Basic',
   };
 </script>

--- a/docs/examples/modules/TabExample/Types/Pointing.example.vue
+++ b/docs/examples/modules/TabExample/Types/Pointing.example.vue
@@ -18,6 +18,6 @@
 
 <script>
   export default {
-    name: 'PointingExample',
+    name: 'Pointing',
   };
 </script>

--- a/docs/examples/modules/TabExample/Types/Secondary.example.vue
+++ b/docs/examples/modules/TabExample/Types/Secondary.example.vue
@@ -18,6 +18,6 @@
 
 <script>
   export default {
-    name: 'SecondaryExample',
+    name: 'Secondary',
   };
 </script>

--- a/docs/examples/modules/TabExample/Types/Text.example.vue
+++ b/docs/examples/modules/TabExample/Types/Text.example.vue
@@ -18,6 +18,6 @@
 
 <script>
   export default {
-    name: 'TextExample',
+    name: 'Text',
   };
 </script>

--- a/docs/examples/modules/TabExample/Usage/ActiveIndex.example.vue
+++ b/docs/examples/modules/TabExample/Usage/ActiveIndex.example.vue
@@ -28,7 +28,7 @@
 
 <script>
   export default {
-    name: 'ActiveIndexExample',
+    name: 'ActiveIndex',
     data: () => ({
       activeIndex: 1,
     }),

--- a/docs/examples/modules/TabExample/Usage/CustomMenuItems.example.vue
+++ b/docs/examples/modules/TabExample/Usage/CustomMenuItems.example.vue
@@ -28,6 +28,6 @@
 
 <script>
   export default {
-    name: 'DefaultActiveIndexExample',
+    name: 'CustomMenuItems',
   };
 </script>

--- a/docs/examples/modules/TabExample/Usage/DefaultActiveIndex.example.vue
+++ b/docs/examples/modules/TabExample/Usage/DefaultActiveIndex.example.vue
@@ -18,6 +18,6 @@
 
 <script>
   export default {
-    name: 'DefaultActiveIndexExample',
+    name: 'DefaultActiveIndex',
   };
 </script>

--- a/docs/examples/modules/TabExample/Usage/OnTabChange.example.vue
+++ b/docs/examples/modules/TabExample/Usage/OnTabChange.example.vue
@@ -68,7 +68,7 @@
 
 <script>
   export default {
-    name: 'OnTabChangeExample',
+    name: 'OnTabChange',
     data: () => ({
       table: {
         inside: null,

--- a/docs/examples/views/AdvertisementExample/BannerAd.example.vue
+++ b/docs/examples/views/AdvertisementExample/BannerAd.example.vue
@@ -9,6 +9,6 @@
 
 <script>
 export default {
-  name: 'BannerAdExample',
+  name: 'BannerAd',
 };
 </script>

--- a/docs/examples/views/AdvertisementExample/ButtonAd.example.vue
+++ b/docs/examples/views/AdvertisementExample/ButtonAd.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'ButtonAdExample',
+  name: 'ButtonAd',
 };
 </script>

--- a/docs/examples/views/AdvertisementExample/CenteredAd.example.vue
+++ b/docs/examples/views/AdvertisementExample/CenteredAd.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'CenteredAdExample',
+  name: 'CenteredAd',
 };
 </script>

--- a/docs/examples/views/AdvertisementExample/CommonUnitsAd.example.vue
+++ b/docs/examples/views/AdvertisementExample/CommonUnitsAd.example.vue
@@ -10,6 +10,6 @@
 
 <script>
 export default {
-  name: 'CommonUnitsAdExample',
+  name: 'CommonUnitsAd',
 };
 </script>

--- a/docs/examples/views/AdvertisementExample/Leaderboards.example.vue
+++ b/docs/examples/views/AdvertisementExample/Leaderboards.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'LeaderboardsAdExample',
+  name: 'Leaderboards',
 };
 </script>

--- a/docs/examples/views/AdvertisementExample/MobileAd.example.vue
+++ b/docs/examples/views/AdvertisementExample/MobileAd.example.vue
@@ -7,6 +7,6 @@
 
 <script>
 export default {
-  name: 'MobileAdExample',
+  name: 'MobileAd',
 };
 </script>

--- a/docs/examples/views/AdvertisementExample/NetboardAd.example.vue
+++ b/docs/examples/views/AdvertisementExample/NetboardAd.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'NetboardAdExample',
+  name: 'NetboardAd',
 };
 </script>

--- a/docs/examples/views/AdvertisementExample/PanoramaAd.example.vue
+++ b/docs/examples/views/AdvertisementExample/PanoramaAd.example.vue
@@ -6,6 +6,6 @@
 
 <script>
 export default {
-  name: 'PanoramaAdExample',
+  name: 'PanoramaAd',
 };
 </script>

--- a/docs/examples/views/AdvertisementExample/SkyscraperAd.example.vue
+++ b/docs/examples/views/AdvertisementExample/SkyscraperAd.example.vue
@@ -7,6 +7,6 @@
 
 <script>
 export default {
-  name: 'SkyscraperAdExample',
+  name: 'SkyscraperAd',
 };
 </script>

--- a/docs/examples/views/AdvertisementExample/StandardAd.example.vue
+++ b/docs/examples/views/AdvertisementExample/StandardAd.example.vue
@@ -8,6 +8,6 @@
 
 <script>
 export default {
-  name: 'StandardAdExample',
+  name: 'StandardAd',
 };
 </script>

--- a/docs/examples/views/AdvertisementExample/TestAd.example.vue
+++ b/docs/examples/views/AdvertisementExample/TestAd.example.vue
@@ -7,6 +7,6 @@
 
 <script>
 export default {
-  name: 'TestAdExample',
+  name: 'TestAd',
 };
 </script>

--- a/docs/examples/views/CardExample/ApprovalCard.example.vue
+++ b/docs/examples/views/CardExample/ApprovalCard.example.vue
@@ -22,6 +22,6 @@
 
 <script>
 export default {
-  name: 'ApprovalCardExample',
+  name: 'ApprovalCard',
 };
 </script>

--- a/docs/examples/views/CardExample/ButtonsCard.example.vue
+++ b/docs/examples/views/CardExample/ButtonsCard.example.vue
@@ -44,6 +44,6 @@
 
 <script>
 export default {
-  name: 'ButtonsCardExample',
+  name: 'ButtonsCard',
 };
 </script>

--- a/docs/examples/views/CardExample/Card1.example.vue
+++ b/docs/examples/views/CardExample/Card1.example.vue
@@ -17,6 +17,6 @@
 
 <script>
 export default {
-  name: 'Card1Example',
+  name: 'Card1',
 };
 </script>

--- a/docs/examples/views/CardExample/Card2.example.vue
+++ b/docs/examples/views/CardExample/Card2.example.vue
@@ -31,6 +31,6 @@
 
 <script>
 export default {
-  name: 'Card2Example',
+  name: 'Card2',
 };
 </script>

--- a/docs/examples/views/CardExample/CardGroup1.example.vue
+++ b/docs/examples/views/CardExample/CardGroup1.example.vue
@@ -43,6 +43,6 @@
 
 <script>
 export default {
-  name: 'CardGroup1Example',
+  name: 'CardGroup1',
 };
 </script>

--- a/docs/examples/views/CardExample/CardGroup2.example.vue
+++ b/docs/examples/views/CardExample/CardGroup2.example.vue
@@ -49,6 +49,6 @@
 
 <script>
 export default {
-  name: 'Card1Example',
+  name: 'CardGroup2',
 };
 </script>

--- a/docs/examples/views/CardExample/CenteredCard.example.vue
+++ b/docs/examples/views/CardExample/CenteredCard.example.vue
@@ -11,6 +11,6 @@
 
 <script>
 export default {
-  name: 'CenteredCardExample',
+  name: 'CenteredCard',
 };
 </script>

--- a/docs/examples/views/CardExample/ColoredCard.example.vue
+++ b/docs/examples/views/CardExample/ColoredCard.example.vue
@@ -46,6 +46,6 @@
 
 <script>
 export default {
-  name: 'ColoredCardExample',
+  name: 'ColoredCard',
 };
 </script>

--- a/docs/examples/views/CardExample/ColumnCountCard.example.vue
+++ b/docs/examples/views/CardExample/ColumnCountCard.example.vue
@@ -55,6 +55,6 @@
 
 <script>
 export default {
-  name: 'ColumnCountCardExample',
+  name: 'ColumnCountCard',
 };
 </script>

--- a/docs/examples/views/CardExample/ContentBlock.example.vue
+++ b/docs/examples/views/CardExample/ContentBlock.example.vue
@@ -45,6 +45,6 @@
 
 <script>
 export default {
-  name: 'ContentBlockExample',
+  name: 'ContentBlock',
 };
 </script>

--- a/docs/examples/views/CardExample/DescriptionCard.example.vue
+++ b/docs/examples/views/CardExample/DescriptionCard.example.vue
@@ -18,6 +18,6 @@
 
 <script>
 export default {
-  name: 'DescriptionCardExample',
+  name: 'DescriptionCard',
 };
 </script>

--- a/docs/examples/views/CardExample/DoublingCard.example.vue
+++ b/docs/examples/views/CardExample/DoublingCard.example.vue
@@ -25,6 +25,6 @@
 
 <script>
 export default {
-  name: 'DoublingCardExample',
+  name: 'DoublingCard',
 };
 </script>

--- a/docs/examples/views/CardExample/ExtraContentCard.example.vue
+++ b/docs/examples/views/CardExample/ExtraContentCard.example.vue
@@ -21,6 +21,6 @@
 
 <script>
 export default {
-  name: 'ExtraContentCardExample',
+  name: 'ExtraContentCard',
 };
 </script>

--- a/docs/examples/views/CardExample/FloatedContentCard.example.vue
+++ b/docs/examples/views/CardExample/FloatedContentCard.example.vue
@@ -19,6 +19,6 @@
 
 <script>
 export default {
-  name: 'FloatedContentCardExample',
+  name: 'FloatedContentCard',
 };
 </script>

--- a/docs/examples/views/CardExample/FluidCard.example.vue
+++ b/docs/examples/views/CardExample/FluidCard.example.vue
@@ -31,6 +31,6 @@
 
 <script>
 export default {
-  name: 'FluidCardExample',
+  name: 'FluidCard',
 };
 </script>

--- a/docs/examples/views/CardExample/HeaderCard.example.vue
+++ b/docs/examples/views/CardExample/HeaderCard.example.vue
@@ -33,6 +33,6 @@
 
 <script>
 export default {
-  name: 'HeaderCardExample',
+  name: 'HeaderCard',
 };
 </script>

--- a/docs/examples/views/CardExample/ImageCard1.example.vue
+++ b/docs/examples/views/CardExample/ImageCard1.example.vue
@@ -23,6 +23,6 @@
 
 <script>
 export default {
-  name: 'ImageCard1Example',
+  name: 'ImageCard1',
 };
 </script>

--- a/docs/examples/views/CardExample/ImageCard2.example.vue
+++ b/docs/examples/views/CardExample/ImageCard2.example.vue
@@ -41,7 +41,7 @@
 
 <script>
 export default {
-  name: 'ImageCard2Example',
+  name: 'ImageCard2',
   data() {
     return {
       cardOneActive: false,

--- a/docs/examples/views/CardExample/LinkCard.example.vue
+++ b/docs/examples/views/CardExample/LinkCard.example.vue
@@ -14,6 +14,6 @@
 
 <script>
 export default {
-  name: 'LinkCardExample',
+  name: 'LinkCard',
 };
 </script>

--- a/docs/examples/views/CardExample/LinkCard1.example.vue
+++ b/docs/examples/views/CardExample/LinkCard1.example.vue
@@ -20,6 +20,6 @@
 
 <script>
 export default {
-  name: 'LinkCard1Example',
+  name: 'LinkCard1',
 };
 </script>

--- a/docs/examples/views/CardExample/LinkCard2.example.vue
+++ b/docs/examples/views/CardExample/LinkCard2.example.vue
@@ -17,6 +17,6 @@
 
 <script>
 export default {
-  name: 'LinkCard2Example',
+  name: 'LinkCard2',
 };
 </script>

--- a/docs/examples/views/CardExample/MetadataCard.example.vue
+++ b/docs/examples/views/CardExample/MetadataCard.example.vue
@@ -15,6 +15,6 @@
 
 <script>
 export default {
-  name: 'MetadataCardExample',
+  name: 'MetadataCard',
 };
 </script>

--- a/docs/examples/views/CardExample/RaisedCard.example.vue
+++ b/docs/examples/views/CardExample/RaisedCard.example.vue
@@ -17,6 +17,6 @@
 
 <script>
 export default {
-  name: 'RaisedCardExample',
+  name: 'RaisedCard',
 };
 </script>

--- a/docs/examples/views/CardExample/RaisedLinkCard.example.vue
+++ b/docs/examples/views/CardExample/RaisedLinkCard.example.vue
@@ -17,6 +17,6 @@
 
 <script>
 export default {
-  name: 'RaisedLinkCardExample',
+  name: 'RaisedLinkCard',
 };
 </script>

--- a/docs/examples/views/CardExample/StackableCard.example.vue
+++ b/docs/examples/views/CardExample/StackableCard.example.vue
@@ -25,6 +25,6 @@
 
 <script>
 export default {
-  name: 'StackableCardExample',
+  name: 'StackableCard',
 };
 </script>

--- a/docs/examples/views/CardExample/TextAlignmentCard.example.vue
+++ b/docs/examples/views/CardExample/TextAlignmentCard.example.vue
@@ -19,6 +19,6 @@
 
 <script>
 export default {
-  name: 'TextAlignmentCardExample',
+  name: 'TextAlignmentCard',
 };
 </script>

--- a/docs/examples/views/CommentExample/Comment.example.vue
+++ b/docs/examples/views/CommentExample/Comment.example.vue
@@ -79,6 +79,6 @@
 
 <script>
 export default {
-  name: 'CommentExample',
+  name: 'Comment',
 };
 </script>

--- a/docs/examples/views/FeedExample/ContentDate.example.vue
+++ b/docs/examples/views/FeedExample/ContentDate.example.vue
@@ -16,7 +16,7 @@
 
 <script>
 export default {
-  name: 'ContentDateExample',
+  name: 'ContentDate',
   data() {
     return {
       imageSrc: 'static/images/avatar/small/jenny.jpg',

--- a/docs/examples/views/FeedExample/ContentDateShorthand.example.vue
+++ b/docs/examples/views/FeedExample/ContentDateShorthand.example.vue
@@ -10,7 +10,7 @@
 
 <script>
 export default {
-  name: 'ContentDateShorthandExample',
+  name: 'ContentDateShorthand',
   data() {
     return {
       image: 'static/images/avatar/small/jenny.jpg',

--- a/docs/examples/views/FeedExample/ExtraImages.example.vue
+++ b/docs/examples/views/FeedExample/ExtraImages.example.vue
@@ -18,6 +18,6 @@
 
 <script>
 export default {
-  name: 'ExtraImagesExample',
+  name: 'ExtraImages',
 };
 </script>

--- a/docs/examples/views/FeedExample/ExtraImagesShorthand.example.vue
+++ b/docs/examples/views/FeedExample/ExtraImagesShorthand.example.vue
@@ -25,7 +25,7 @@
 
 <script>
 export default {
-  name: 'ExtraImagesShorthandExample',
+  name: 'ExtraImagesShorthand',
   data() {
     return {
       image: 'static/images/avatar/small/helen.jpg',

--- a/docs/examples/views/FeedExample/ExtraText.example.vue
+++ b/docs/examples/views/FeedExample/ExtraText.example.vue
@@ -17,6 +17,6 @@
 
 <script>
 export default {
-  name: 'ExtraTextExample',
+  name: 'ExtraText',
 };
 </script>

--- a/docs/examples/views/FeedExample/ExtraTextShorthand.example.vue
+++ b/docs/examples/views/FeedExample/ExtraTextShorthand.example.vue
@@ -25,7 +25,7 @@
 
 <script>
 export default {
-  name: 'ExtraImagesShorthandExample',
+  name: 'ExtraTextShorthand',
   data() {
     return {
       image: 'static/images/avatar/small/laura.jpg',

--- a/docs/examples/views/FeedExample/Feed.example.vue
+++ b/docs/examples/views/FeedExample/Feed.example.vue
@@ -96,6 +96,6 @@
 
 <script>
 export default {
-  name: 'FeedExample',
+  name: 'Feed',
 };
 </script>

--- a/docs/examples/views/FeedExample/FeedShorthand.example.vue
+++ b/docs/examples/views/FeedExample/FeedShorthand.example.vue
@@ -4,7 +4,7 @@
 
 <script>
 export default {
-  name: 'FeedShorthandExample',
+  name: 'FeedShorthand',
   data() {
     return {
       events: [{

--- a/docs/examples/views/FeedExample/IconLabel.example.vue
+++ b/docs/examples/views/FeedExample/IconLabel.example.vue
@@ -16,6 +16,6 @@
 
 <script>
 export default {
-  name: 'IconLabelExample',
+  name: 'IconLabel',
 };
 </script>

--- a/docs/examples/views/FeedExample/IconLabelShorthand.example.vue
+++ b/docs/examples/views/FeedExample/IconLabelShorthand.example.vue
@@ -21,6 +21,6 @@
 
 <script>
 export default {
-  name: 'IconLabelShorthandExample',
+  name: 'IconLabelShorthand',
 };
 </script>

--- a/docs/examples/views/FeedExample/ImageLabel.example.vue
+++ b/docs/examples/views/FeedExample/ImageLabel.example.vue
@@ -13,6 +13,6 @@
 
 <script>
 export default {
-  name: 'ImageLabelExample',
+  name: 'ImageLabel',
 };
 </script>

--- a/docs/examples/views/FeedExample/ImageLabelShorthand.example.vue
+++ b/docs/examples/views/FeedExample/ImageLabelShorthand.example.vue
@@ -12,6 +12,6 @@
 
 <script>
 export default {
-  name: 'ImageLabelShorthandExample',
+  name: 'ImageLabelShorthand',
 };
 </script>

--- a/docs/examples/views/FeedExample/SizeLarge.example.vue
+++ b/docs/examples/views/FeedExample/SizeLarge.example.vue
@@ -53,6 +53,6 @@
 
 <script>
 export default {
-  name: 'SizeLargeExample',
+  name: 'SizeLarge',
 };
 </script>

--- a/docs/examples/views/FeedExample/SizeSmall.example.vue
+++ b/docs/examples/views/FeedExample/SizeSmall.example.vue
@@ -38,6 +38,6 @@
 
 <script>
 export default {
-  name: 'SizeSmallExample',
+  name: 'SizeSmall',
 };
 </script>

--- a/docs/examples/views/FeedExample/SummaryDate.example.vue
+++ b/docs/examples/views/FeedExample/SummaryDate.example.vue
@@ -16,6 +16,6 @@
 
 <script>
 export default {
-  name: 'SummaryDateExample',
+  name: 'SummaryDate',
 };
 </script>

--- a/docs/examples/views/FeedExample/SummaryDateShorthand.example.vue
+++ b/docs/examples/views/FeedExample/SummaryDateShorthand.example.vue
@@ -15,6 +15,6 @@
 
 <script>
 export default {
-  name: 'SummaryDateShorthandExample',
+  name: 'SummaryDateShorthand',
 };
 </script>

--- a/docs/examples/views/ItemExample/ContentContent.example.vue
+++ b/docs/examples/views/ItemExample/ContentContent.example.vue
@@ -17,6 +17,6 @@
 
 <script>
 export default {
-  name: 'ContentContentExample',
+  name: 'ContentContent',
 };
 </script>

--- a/docs/examples/views/ItemExample/ContentHeader.example.vue
+++ b/docs/examples/views/ItemExample/ContentHeader.example.vue
@@ -23,6 +23,6 @@
 
 <script>
 export default {
-  name: 'ContentHeaderExample',
+  name: 'ContentHeader',
 };
 </script>

--- a/docs/examples/views/ItemExample/ContentImage.example.vue
+++ b/docs/examples/views/ItemExample/ContentImage.example.vue
@@ -14,6 +14,6 @@
 
 <script>
 export default {
-  name: 'ContentImageExample',
+  name: 'ContentImage',
 };
 </script>

--- a/docs/examples/views/ItemExample/ContentMeta.example.vue
+++ b/docs/examples/views/ItemExample/ContentMeta.example.vue
@@ -53,6 +53,6 @@
 
 <script>
 export default {
-  name: 'ContentHeaderExample',
+  name: 'ContentMeta',
 };
 </script>

--- a/docs/examples/views/ItemExample/ItemGroup.example.vue
+++ b/docs/examples/views/ItemExample/ItemGroup.example.vue
@@ -41,6 +41,6 @@
 
 <script>
 export default {
-  name: 'ItemGroupExample',
+  name: 'ItemGroup',
 };
 </script>

--- a/docs/examples/views/StatisticExample/Statistic.example.vue
+++ b/docs/examples/views/StatisticExample/Statistic.example.vue
@@ -18,7 +18,7 @@
 
 <script>
 export default {
-  name: 'StatisticExample',
+  name: 'Statistic',
 };
 </script>
 

--- a/docs/examples/views/StatisticExample/StatisticColored.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticColored.example.vue
@@ -101,6 +101,6 @@
 
 <script>
 export default {
-  name: 'StatisticColoredExample',
+  name: 'StatisticColored',
 };
 </script>

--- a/docs/examples/views/StatisticExample/StatisticContentLabel.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticContentLabel.example.vue
@@ -7,6 +7,6 @@
 
 <script>
 export default {
-  name: 'StatisticContentLabelExample',
+  name: 'StatisticContentLabel',
 };
 </script>

--- a/docs/examples/views/StatisticExample/StatisticContentValue.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticContentValue.example.vue
@@ -39,6 +39,6 @@
 
 <script>
 export default {
-  name: 'StatisticContentValueExample',
+  name: 'StatisticContentValue',
 };
 </script>

--- a/docs/examples/views/StatisticExample/StatisticEvenlyDivided.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticEvenlyDivided.example.vue
@@ -39,6 +39,6 @@
 
 <script>
 export default {
-  name: 'StatisticEvenlyDividedExample',
+  name: 'StatisticEvenlyDivided',
 };
 </script>

--- a/docs/examples/views/StatisticExample/StatisticFloated.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticFloated.example.vue
@@ -43,6 +43,6 @@
 
 <script>
 export default {
-  name: 'StatisticFloatedExample',
+  name: 'StatisticFloated',
 };
 </script>

--- a/docs/examples/views/StatisticExample/StatisticGroup.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticGroup.example.vue
@@ -17,6 +17,6 @@
 
 <script>
 export default {
-  name: 'StatisticGroupExample',
+  name: 'StatisticGroup',
 };
 </script>

--- a/docs/examples/views/StatisticExample/StatisticHorizontal.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticHorizontal.example.vue
@@ -27,7 +27,7 @@
 
 <script>
 export default {
-  name: 'StatisticHorizontalExample',
+  name: 'StatisticHorizontal',
 };
 </script>
 

--- a/docs/examples/views/StatisticExample/StatisticInverted.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticInverted.example.vue
@@ -111,6 +111,6 @@
 
 <script>
 export default {
-  name: 'StatisticInvertedExample',
+  name: 'StatisticInverted',
 };
 </script>

--- a/docs/examples/views/StatisticExample/StatisticSize.example.vue
+++ b/docs/examples/views/StatisticExample/StatisticSize.example.vue
@@ -108,6 +108,6 @@
 
 <script>
 export default {
-  name: 'StatisticSizeExample',
+  name: 'StatisticSize',
 };
 </script>


### PR DESCRIPTION
## Problem

The `Edit` button which redirects to the GitHub's edit page for the component file **does not** work properly because `getComponentFromString` (see `docs/Example.vue:150`) doesn't provide a way to fetch the component's filename.

## Solution

As you can see at `docs/Example.vue:153`, the output from `getComponentFromString` includes the component' s **name** attribute.

My solution would be to change all the example components' **name** attribute to reflect the component's filename.

## Checklist

- [x] Update`name` attribute for the example components (to equal the component's filename)
- [ ] Nested directories support