### PR TITLE
[WIP] Adding comment variations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,8 +47,7 @@ module.exports = {
     'vue/require-render-return': 'error',
     'vue/require-valid-default-prop': 'error',
     'vue/return-in-computed-property': 'error',
-    // TODO: enable when https://github.com/vuejs/eslint-plugin-vue/issues/217 is fixed
-    'vue/html-end-tags': 'off',
+    'vue/html-end-tags': 'on',
     'vue/no-async-in-computed-properties': 'error',
     'vue/no-duplicate-attributes': 'error',
     'vue/no-side-effects-in-computed-properties': 'error',
@@ -62,5 +61,6 @@ module.exports = {
     // 'vue/no-multi-spaces': 'error',
     'vue/v-bind-style': 'error',
     'vue/v-on-style': 'error',
+    'indent': ['warn', 2]
   }
 }

--- a/docs/examples/views/CommentExample/Minimal.example.vue
+++ b/docs/examples/views/CommentExample/Minimal.example.vue
@@ -1,0 +1,84 @@
+<template lang="html">
+  <sui-comment-group minimal>
+    <h3 is="sui-header" dividing>Comments</h3>
+
+    <sui-comment>
+      <sui-comment-avatar src="static/images/avatar/small/matt.jpg" />
+      <sui-comment-content>
+        <a is="sui-comment-author">Matt</a>
+        <sui-comment-metadata>
+          <div>Today at 5:42PM</div>
+        </sui-comment-metadata>
+        <sui-comment-text>How artistic!</sui-comment-text>
+        <sui-comment-actions>
+          <sui-comment-action>Reply</sui-comment-action>
+        </sui-comment-actions>
+      </sui-comment-content>
+    </sui-comment>
+
+    <sui-comment>
+      <sui-comment-avatar src="static/images/avatar/small/elliot.jpg" />
+      <sui-comment-content>
+        <a is="sui-comment-author">Elliot Fu</a>
+        <sui-comment-metadata>
+          <div>Yesterday at 12:30AM</div>
+        </sui-comment-metadata>
+        <sui-comment-text>
+          <p>This has been very useful for my research. Thanks as well!</p>
+        </sui-comment-text>
+        <sui-comment-actions>
+          <sui-comment-action>Reply</sui-comment-action>
+        </sui-comment-actions>
+      </sui-comment-content>
+      <sui-comment-group>
+        <sui-comment>
+          <sui-comment-avatar src="static/images/avatar/small/jenny.jpg" />
+          <sui-comment-content>
+            <a is="sui-comment-author">Jenny Hess</a>
+            <sui-comment-metadata>
+              <div>Just now</div>
+            </sui-comment-metadata>
+            <sui-comment-text>
+              Elliot you are always so right :)
+            </sui-comment-text>
+            <sui-comment-actions>
+              <sui-comment-action>Reply</sui-comment-action>
+            </sui-comment-actions>
+          </sui-comment-content>
+        </sui-comment>
+      </sui-comment-group>
+    </sui-comment>
+
+    <sui-comment>
+      <sui-comment-avatar src="static/images/avatar/small/joe.jpg" />
+      <sui-comment-content>
+        <a is="sui-comment-author">Joe Henderson</a>
+        <sui-comment-metadata>
+          <div>5 days ago</div>
+        </sui-comment-metadata>
+        <sui-comment-text>
+          Dude, this is awesome. Thanks so much
+        </sui-comment-text>
+        <sui-comment-actions>
+          <sui-comment-action>Reply</sui-comment-action>
+        </sui-comment-actions>
+      </sui-comment-content>
+    </sui-comment>
+
+    <form reply>
+      <form-text-area />
+      <sui-button
+        content="Add Reply"
+        label-position="left"
+        icon="edit"
+        primary
+      />
+    </form>
+  </sui-comment-group>
+</template>
+
+<script>
+    export default {
+        name: 'MinimalExample',
+    };
+</script>

--- a/docs/examples/views/CommentExample/Size.example.vue
+++ b/docs/examples/views/CommentExample/Size.example.vue
@@ -1,0 +1,84 @@
+<template lang="html">
+  <sui-comment-group size="massive" threaded>
+    <h3 is="sui-header" dividing>Comments</h3>
+
+    <sui-comment>
+      <sui-comment-avatar src="static/images/avatar/small/matt.jpg" />
+      <sui-comment-content>
+        <a is="sui-comment-author">Matt</a>
+        <sui-comment-metadata>
+          <div>Today at 5:42PM</div>
+        </sui-comment-metadata>
+        <sui-comment-text>How artistic!</sui-comment-text>
+        <sui-comment-actions>
+          <sui-comment-action>Reply</sui-comment-action>
+        </sui-comment-actions>
+      </sui-comment-content>
+    </sui-comment>
+
+    <sui-comment>
+      <sui-comment-avatar src="static/images/avatar/small/elliot.jpg" />
+      <sui-comment-content>
+        <a is="sui-comment-author">Elliot Fu</a>
+        <sui-comment-metadata>
+          <div>Yesterday at 12:30AM</div>
+        </sui-comment-metadata>
+        <sui-comment-text>
+          <p>This has been very useful for my research. Thanks as well!</p>
+        </sui-comment-text>
+        <sui-comment-actions>
+          <sui-comment-action>Reply</sui-comment-action>
+        </sui-comment-actions>
+      </sui-comment-content>
+      <sui-comment-group>
+        <sui-comment>
+          <sui-comment-avatar src="static/images/avatar/small/jenny.jpg" />
+          <sui-comment-content>
+            <a is="sui-comment-author">Jenny Hess</a>
+            <sui-comment-metadata>
+              <div>Just now</div>
+            </sui-comment-metadata>
+            <sui-comment-text>
+              Elliot you are always so right :)
+            </sui-comment-text>
+            <sui-comment-actions>
+              <sui-comment-action>Reply</sui-comment-action>
+            </sui-comment-actions>
+          </sui-comment-content>
+        </sui-comment>
+      </sui-comment-group>
+    </sui-comment>
+
+    <sui-comment>
+      <sui-comment-avatar src="static/images/avatar/small/joe.jpg" />
+      <sui-comment-content>
+        <a is="sui-comment-author">Joe Henderson</a>
+        <sui-comment-metadata>
+          <div>5 days ago</div>
+        </sui-comment-metadata>
+        <sui-comment-text>
+          Dude, this is awesome. Thanks so much
+        </sui-comment-text>
+        <sui-comment-actions>
+          <sui-comment-action>Reply</sui-comment-action>
+        </sui-comment-actions>
+      </sui-comment-content>
+    </sui-comment>
+
+    <form reply>
+      <form-text-area />
+      <sui-button
+        content="Add Reply"
+        label-position="left"
+        icon="edit"
+        primary
+      />
+    </form>
+  </sui-comment-group>
+</template>
+
+<script>
+    export default {
+        name: 'SizeExample',
+    };
+</script>

--- a/docs/examples/views/CommentExample/Threaded.example.vue
+++ b/docs/examples/views/CommentExample/Threaded.example.vue
@@ -1,0 +1,84 @@
+<template lang="html">
+  <sui-comment-group threaded>
+    <h3 is="sui-header" dividing>Comments</h3>
+
+    <sui-comment>
+      <sui-comment-avatar src="static/images/avatar/small/matt.jpg" />
+      <sui-comment-content>
+        <a is="sui-comment-author">Matt</a>
+        <sui-comment-metadata>
+          <div>Today at 5:42PM</div>
+        </sui-comment-metadata>
+        <sui-comment-text>How artistic!</sui-comment-text>
+        <sui-comment-actions>
+          <sui-comment-action>Reply</sui-comment-action>
+        </sui-comment-actions>
+      </sui-comment-content>
+    </sui-comment>
+
+    <sui-comment>
+      <sui-comment-avatar src="static/images/avatar/small/elliot.jpg" />
+      <sui-comment-content>
+        <a is="sui-comment-author">Elliot Fu</a>
+        <sui-comment-metadata>
+          <div>Yesterday at 12:30AM</div>
+        </sui-comment-metadata>
+        <sui-comment-text>
+          <p>This has been very useful for my research. Thanks as well!</p>
+        </sui-comment-text>
+        <sui-comment-actions>
+          <sui-comment-action>Reply</sui-comment-action>
+        </sui-comment-actions>
+      </sui-comment-content>
+      <sui-comment-group>
+        <sui-comment>
+          <sui-comment-avatar src="static/images/avatar/small/jenny.jpg" />
+          <sui-comment-content>
+            <a is="sui-comment-author">Jenny Hess</a>
+            <sui-comment-metadata>
+              <div>Just now</div>
+            </sui-comment-metadata>
+            <sui-comment-text>
+              Elliot you are always so right :)
+            </sui-comment-text>
+            <sui-comment-actions>
+              <sui-comment-action>Reply</sui-comment-action>
+            </sui-comment-actions>
+          </sui-comment-content>
+        </sui-comment>
+      </sui-comment-group>
+    </sui-comment>
+
+    <sui-comment>
+      <sui-comment-avatar src="static/images/avatar/small/joe.jpg" />
+      <sui-comment-content>
+        <a is="sui-comment-author">Joe Henderson</a>
+        <sui-comment-metadata>
+          <div>5 days ago</div>
+        </sui-comment-metadata>
+        <sui-comment-text>
+          Dude, this is awesome. Thanks so much
+        </sui-comment-text>
+        <sui-comment-actions>
+          <sui-comment-action>Reply</sui-comment-action>
+        </sui-comment-actions>
+      </sui-comment-content>
+    </sui-comment>
+
+    <form reply>
+      <form-text-area />
+      <sui-button
+        content="Add Reply"
+        label-position="left"
+        icon="edit"
+        primary
+      />
+    </form>
+  </sui-comment-group>
+</template>
+
+<script>
+export default {
+  name: 'ThreadedExample',
+};
+</script>

--- a/docs/examples/views/CommentExample/index.js
+++ b/docs/examples/views/CommentExample/index.js
@@ -1,4 +1,7 @@
 import Comment from './Comment.example';
+import Threaded from './Threaded.example';
+import Minimal from './Minimal.example';
+import Size from './Size.example';
 
 export default [
   {
@@ -8,6 +11,21 @@ export default [
         title: 'Comments',
         description: 'A basic list of comments',
         component: Comment,
+      },
+      {
+        title: 'Threaded',
+        description: 'A comment list can be threaded to showing the relationship between conversations',
+        component: Threaded,
+      },
+      {
+        title: 'Minimal',
+        description: 'Comments can hide extra information unless a user shows intent to interact with a comment',
+        component: Minimal,
+      },
+      {
+        title: 'Size',
+        description: 'Comments can have different sizes',
+        component: Size,
       },
     ],
   },

--- a/src/lib/mixins/classMixin.js
+++ b/src/lib/mixins/classMixin.js
@@ -7,5 +7,9 @@ export const classMixin = {
       const inGroup = ownName && parentName && parentName.match(new RegExp(`^${ownName}.*Group$`));
       return inGroup ? '' : 'ui';
     },
+    getParentName() {
+      return (this.$parent && this.$parent.constructor.options &&
+        this.$parent.constructor.options.name) || '';
+    },
   },
 };

--- a/src/views/Comment/CommentGroup.jsx
+++ b/src/views/Comment/CommentGroup.jsx
@@ -1,9 +1,9 @@
-import { SemanticUIVueMixin } from '../../lib';
+import { classMixin, SemanticUIVueMixin } from '../../lib';
 import { Enum } from '../../lib/PropTypes';
 
 export default {
   name: 'SuiCommentGroup',
-  mixins: [SemanticUIVueMixin],
+  mixins: [SemanticUIVueMixin, classMixin],
   props: {
     threaded: {
       type: Boolean,
@@ -19,17 +19,18 @@ export default {
   },
   render() {
     const ElementType = this.getElementType();
-    const classList = this.classes(
-      'ui',
+    const classList = [
       'comments',
       this.threaded && 'threaded',
       this.minimal && 'minimal',
       this.size,
-    );
+    ];
+    const parentName = this.getParentName();
+    if (parentName !== 'SuiComment') classList.push('ui');
     return (
       <ElementType
         {...this.getChildPropsAndListeners()}
-        class={classList}
+        class={this.classes(...classList)}
       >
         {this.$slots.default}
       </ElementType>

--- a/src/views/Comment/CommentGroup.jsx
+++ b/src/views/Comment/CommentGroup.jsx
@@ -1,17 +1,35 @@
 import { SemanticUIVueMixin } from '../../lib';
+import { Enum } from '../../lib/PropTypes';
 
 export default {
   name: 'SuiCommentGroup',
   mixins: [SemanticUIVueMixin],
+  props: {
+    threaded: {
+      type: Boolean,
+      description: 'A comment list can be threaded to showing the relationship between conversations.',
+      default: false,
+    },
+    minimal: {
+      type: Boolean,
+      description: 'Comments can hide extra information unless a user shows intent to interact with a comment.',
+      default: false,
+    },
+    size: Enum.Size(),
+  },
   render() {
     const ElementType = this.getElementType();
+    const classList = this.classes(
+      'ui',
+      'comments',
+      this.threaded && 'threaded',
+      this.minimal && 'minimal',
+      this.size,
+    );
     return (
       <ElementType
         {...this.getChildPropsAndListeners()}
-        class={this.classes(
-          'ui',
-          'comments',
-        )}
+        class={classList}
       >
         {this.$slots.default}
       </ElementType>

--- a/test/__snapshots__/Examples.md
+++ b/test/__snapshots__/Examples.md
@@ -3679,6 +3679,42 @@ Vue.use(PortalVue);
       Reply</button></form></div>"
 ```
 
+##     `Threaded`
+
+####       `should match snapshot`
+
+```
+"<div class=\"comments threaded ui\"><h3 class=\"ui dividing header\">Comments</h3> <div class=\"ui comment\"><div class=\"avatar\"><img src=\"static/images/avatar/small/matt.jpg\"></div> <div class=\"content\"><a class=\"author\">Matt</a> <div class=\"metadata\"><div>Today at 5:42PM</div></div> <div class=\"text\">How artistic!</div> <div class=\"actions\"><a>Reply</a></div></div></div> <div class=\"ui comment\"><div class=\"avatar\"><img src=\"static/images/avatar/small/elliot.jpg\"></div> <div class=\"content\"><a class=\"author\">Elliot Fu</a> <div class=\"metadata\"><div>Yesterday at 12:30AM</div></div> <div class=\"text\"><p>This has been very useful for my research. Thanks as well!</p></div> <div class=\"actions\"><a>Reply</a></div></div> <div class=\"comments\"><div class=\"ui comment\"><div class=\"avatar\"><img src=\"static/images/avatar/small/jenny.jpg\"></div> <div class=\"content\"><a class=\"author\">Jenny Hess</a> <div class=\"metadata\"><div>Just now</div></div> <div class=\"text\">
+            Elliot you are always so right :)
+          </div> <div class=\"actions\"><a>Reply</a></div></div></div></div></div> <div class=\"ui comment\"><div class=\"avatar\"><img src=\"static/images/avatar/small/joe.jpg\"></div> <div class=\"content\"><a class=\"author\">Joe Henderson</a> <div class=\"metadata\"><div>5 days ago</div></div> <div class=\"text\">
+        Dude, this is awesome. Thanks so much
+      </div> <div class=\"actions\"><a>Reply</a></div></div></div> <form reply=\"\"><form-text-area></form-text-area> <button role=\"button\" class=\"ui icon left labeled primary button\"><i class=\"edit icon\"></i>Add Reply</button></form></div>"
+```
+
+##     `Minimal`
+
+####       `should match snapshot`
+
+```
+"<div class=\"comments minimal ui\"><h3 class=\"ui dividing header\">Comments</h3> <div class=\"ui comment\"><div class=\"avatar\"><img src=\"static/images/avatar/small/matt.jpg\"></div> <div class=\"content\"><a class=\"author\">Matt</a> <div class=\"metadata\"><div>Today at 5:42PM</div></div> <div class=\"text\">How artistic!</div> <div class=\"actions\"><a>Reply</a></div></div></div> <div class=\"ui comment\"><div class=\"avatar\"><img src=\"static/images/avatar/small/elliot.jpg\"></div> <div class=\"content\"><a class=\"author\">Elliot Fu</a> <div class=\"metadata\"><div>Yesterday at 12:30AM</div></div> <div class=\"text\"><p>This has been very useful for my research. Thanks as well!</p></div> <div class=\"actions\"><a>Reply</a></div></div> <div class=\"comments\"><div class=\"ui comment\"><div class=\"avatar\"><img src=\"static/images/avatar/small/jenny.jpg\"></div> <div class=\"content\"><a class=\"author\">Jenny Hess</a> <div class=\"metadata\"><div>Just now</div></div> <div class=\"text\">
+            Elliot you are always so right :)
+          </div> <div class=\"actions\"><a>Reply</a></div></div></div></div></div> <div class=\"ui comment\"><div class=\"avatar\"><img src=\"static/images/avatar/small/joe.jpg\"></div> <div class=\"content\"><a class=\"author\">Joe Henderson</a> <div class=\"metadata\"><div>5 days ago</div></div> <div class=\"text\">
+        Dude, this is awesome. Thanks so much
+      </div> <div class=\"actions\"><a>Reply</a></div></div></div> <form reply=\"\"><form-text-area></form-text-area> <button role=\"button\" class=\"ui icon left labeled primary button\"><i class=\"edit icon\"></i>Add Reply</button></form></div>"
+```
+
+##     `Size`
+
+####       `should match snapshot`
+
+```
+"<div class=\"comments threaded massive ui\"><h3 class=\"ui dividing header\">Comments</h3> <div class=\"ui comment\"><div class=\"avatar\"><img src=\"static/images/avatar/small/matt.jpg\"></div> <div class=\"content\"><a class=\"author\">Matt</a> <div class=\"metadata\"><div>Today at 5:42PM</div></div> <div class=\"text\">How artistic!</div> <div class=\"actions\"><a>Reply</a></div></div></div> <div class=\"ui comment\"><div class=\"avatar\"><img src=\"static/images/avatar/small/elliot.jpg\"></div> <div class=\"content\"><a class=\"author\">Elliot Fu</a> <div class=\"metadata\"><div>Yesterday at 12:30AM</div></div> <div class=\"text\"><p>This has been very useful for my research. Thanks as well!</p></div> <div class=\"actions\"><a>Reply</a></div></div> <div class=\"comments\"><div class=\"ui comment\"><div class=\"avatar\"><img src=\"static/images/avatar/small/jenny.jpg\"></div> <div class=\"content\"><a class=\"author\">Jenny Hess</a> <div class=\"metadata\"><div>Just now</div></div> <div class=\"text\">
+            Elliot you are always so right :)
+          </div> <div class=\"actions\"><a>Reply</a></div></div></div></div></div> <div class=\"ui comment\"><div class=\"avatar\"><img src=\"static/images/avatar/small/joe.jpg\"></div> <div class=\"content\"><a class=\"author\">Joe Henderson</a> <div class=\"metadata\"><div>5 days ago</div></div> <div class=\"text\">
+        Dude, this is awesome. Thanks so much
+      </div> <div class=\"actions\"><a>Reply</a></div></div></div> <form reply=\"\"><form-text-area></form-text-area> <button role=\"button\" class=\"ui icon left labeled primary button\"><i class=\"edit icon\"></i>Add Reply</button></form></div>"
+```
+
 ## `FeedExample`
 
 ##   `Types`

--- a/test/specs/views/Comment/CommentGroup.spec.js
+++ b/test/specs/views/Comment/CommentGroup.spec.js
@@ -1,0 +1,39 @@
+import { shallowMount } from '@vue/test-utils';
+import CommentGroup from 'src/views/Comment/CommentGroup';
+import Comment from 'src/views/Comment/Comment';
+
+describe('CommentGroup', () => {
+  let wrapper;
+
+  it('Renders properly', () => {
+    wrapper = shallowMount(CommentGroup);
+    expect(wrapper).to.be.ok;
+  });
+
+  it('It applies threaded variation', () => {
+    wrapper = shallowMount(CommentGroup, {
+      propsData: {
+        threaded: true,
+      },
+    });
+    expect(wrapper.classes()).to.contain('threaded');
+  });
+
+  it('It applies minimal variation', () => {
+    wrapper = shallowMount(CommentGroup, {
+      propsData: {
+        minimal: true,
+      },
+    });
+    expect(wrapper.classes()).to.contain('minimal');
+  });
+
+  // this is required because the ui class will override the font-size
+  it('It does not apply ui class when its inside a Comment', () => {
+    wrapper = shallowMount(CommentGroup, {
+      parentComponent: Comment,
+    });
+    expect(wrapper.vm.$parent.$options.name).to.be.equal('SuiComment');
+    expect(wrapper.classes()).to.not.contain('ui');
+  });
+});


### PR DESCRIPTION
Adding comment variations:

1. Threaded
2. Minimal
3. Size

I found some very interesting thing while I was coding this feature. In this lib when we have a "comments" inside another "comments" we're adding the "ui" class. If it does the inner comments will not apply the right size, so I had to ensure that we "ui" class will not be applied when we have nested comments.
This is how it looked so far:
![image](https://user-images.githubusercontent.com/33661847/68080819-bb19a600-fde1-11e9-838b-6c10fb2c4584.png)

This is how it has to look:
![image](https://user-images.githubusercontent.com/33661847/68080840-33806700-fde2-11e9-8cbe-4f185f38c2a4.png)
