### PR TITLE
Add collapsed comment group functionality, test, and definition

### DIFF
--- a/docs/__tests__/__snapshots__/docs.spec.js.snap
+++ b/docs/__tests__/__snapshots__/docs.spec.js.snap
@@ -8627,6 +8627,50 @@ exports[`Examples ./views/Card/TextAlignmentCard.example.vue should match snapsh
 </div>"
 `;
 
+exports[`Examples ./views/Comment/Collapsed.example.vue should match snapshot 1`] = `
+"<div class=\\"comments ui\\">
+  <div class=\\"ui comment\\">
+    <div class=\\"avatar\\"><img src=\\"static/images/avatar/small/christian.jpg\\"></div>
+    <div class=\\"content\\"><a class=\\"author\\">Christian Rocha</a>
+      <div class=\\"metadata\\">
+        <div>2 days ago</div>
+      </div>
+      <div class=\\"text\\">I'm very interested in this motherboard. Do you know if it'd work in
+        an Intel LGA775 CPU socket?</div>
+      <div class=\\"actions\\"><a>Reply</a></div>
+    </div>
+    <div class=\\"comments collapsed\\">
+      <div class=\\"ui comment\\">
+        <div class=\\"avatar\\"><img src=\\"static/images/avatar/small/elliot.jpg\\"></div>
+        <div class=\\"content\\"><a class=\\"author\\">Elliot Fu</a>
+          <div class=\\"metadata\\">
+            <div>1 day ago</div>
+          </div>
+          <div class=\\"text\\">
+            No it won't.
+          </div>
+          <div class=\\"actions\\"><a>Reply</a></div>
+        </div>
+        <div class=\\"comments\\">
+          <div class=\\"ui comment\\">
+            <div class=\\"avatar\\"><img src=\\"static/images/avatar/small/jenny.jpg\\"></div>
+            <div class=\\"content\\"><a class=\\"author\\">Jenny Hess</a>
+              <div class=\\"metadata\\">
+                <div>20 minutes ago</div>
+              </div>
+              <div class=\\"text\\">
+                Maybe it would.
+              </div>
+              <div class=\\"actions\\"><a>Reply</a></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>"
+`;
+
 exports[`Examples ./views/Comment/Comment.example.vue should match snapshot 1`] = `
 "<div class=\\"comments ui\\">
   <h3 class=\\"ui dividing header\\">Comments</h3>

--- a/docs/definitions/views/Comment/Collapsed.example.vue
+++ b/docs/definitions/views/Comment/Collapsed.example.vue
@@ -1,0 +1,60 @@
+<template lang="html">
+  <sui-comment-group>
+    <sui-comment>
+      <sui-comment-avatar src="static/images/avatar/small/christian.jpg" />
+      <sui-comment-content>
+        <a is="sui-comment-author">Christian Rocha</a>
+        <sui-comment-metadata>
+          <div>2 days ago</div>
+        </sui-comment-metadata>
+        <sui-comment-text
+          >I'm very interested in this motherboard. Do you know if it'd work in
+          an Intel LGA775 CPU socket?</sui-comment-text
+        >
+        <sui-comment-actions>
+          <sui-comment-action>Reply</sui-comment-action>
+        </sui-comment-actions>
+      </sui-comment-content>
+      <sui-comment-group collapsed>
+        <sui-comment>
+          <sui-comment-avatar src="static/images/avatar/small/elliot.jpg" />
+          <sui-comment-content>
+            <a is="sui-comment-author">Elliot Fu</a>
+            <sui-comment-metadata>
+              <div>1 day ago</div>
+            </sui-comment-metadata>
+            <sui-comment-text>
+              No it won't.
+            </sui-comment-text>
+            <sui-comment-actions>
+              <sui-comment-action>Reply</sui-comment-action>
+            </sui-comment-actions>
+          </sui-comment-content>
+          <sui-comment-group>
+            <sui-comment>
+              <sui-comment-avatar src="static/images/avatar/small/jenny.jpg" />
+              <sui-comment-content>
+                <a is="sui-comment-author">Jenny Hess</a>
+                <sui-comment-metadata>
+                  <div>20 minutes ago</div>
+                </sui-comment-metadata>
+                <sui-comment-text>
+                  Maybe it would.
+                </sui-comment-text>
+                <sui-comment-actions>
+                  <sui-comment-action>Reply</sui-comment-action>
+                </sui-comment-actions>
+              </sui-comment-content>
+            </sui-comment>
+          </sui-comment-group>
+        </sui-comment>
+      </sui-comment-group>
+    </sui-comment>
+  </sui-comment-group>
+</template>
+
+<script>
+export default {
+  name: 'MinimalExample',
+};
+</script>

--- a/docs/definitions/views/Comment/Collapsed.example.vue
+++ b/docs/definitions/views/Comment/Collapsed.example.vue
@@ -55,6 +55,6 @@
 
 <script>
 export default {
-  name: 'MinimalExample',
+  name: 'CollapsedExample',
 };
 </script>

--- a/docs/definitions/views/Comment/index.js
+++ b/docs/definitions/views/Comment/index.js
@@ -10,6 +10,16 @@ export default [
     ],
   },
   {
+    name: 'States',
+    examples: [
+      {
+        name: 'Collapsed',
+        description: 'Comments can be collapsed, or hidden from view',
+        file: 'Collapsed',
+      },
+    ],
+  },
+  {
     name: 'Variations',
     examples: [
       {

--- a/src/views/Comment/CommentGroup.jsx
+++ b/src/views/Comment/CommentGroup.jsx
@@ -8,13 +8,18 @@ export default {
     threaded: {
       type: Boolean,
       description:
-        'A comment list can be threaded to showing the relationship between conversations.',
+        'A comment list can be threaded to showing the relationship between conversations',
       default: false,
     },
     minimal: {
       type: Boolean,
       description:
-        'Comments can hide extra information unless a user shows intent to interact with a comment.',
+        'Comments can hide extra information unless a user shows intent to interact with a comment',
+      default: false,
+    },
+    collapsed: {
+      type: Boolean,
+      description: 'Comments can be collapsed, or hidden from view',
       default: false,
     },
     size: Enum.Size(),
@@ -25,6 +30,7 @@ export default {
       'comments',
       this.threaded && 'threaded',
       this.minimal && 'minimal',
+      this.collapsed && 'collapsed',
       this.size,
     ];
     const parentName = this.getParentName();

--- a/src/views/Comment/__tests__/CommentGroup.spec.js
+++ b/src/views/Comment/__tests__/CommentGroup.spec.js
@@ -28,6 +28,15 @@ describe('CommentGroup', () => {
     expect(wrapper.classes()).toContain('minimal');
   });
 
+  it('It applies collapsed state', () => {
+    wrapper = shallowMount(CommentGroup, {
+      propsData: {
+        collapsed: true,
+      },
+    });
+    expect(wrapper.classes()).toContain('collapsed');
+  });
+
   // this is required because the ui class will override the font-size
   it('It does not apply ui class when its inside a Comment', () => {
     wrapper = shallowMount(CommentGroup, {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Users can now pass the collapsed prop to sui-comment-group components and it passes newly created test and behaves as it should in the browser. I also updated the docs accordingly.


* **What is the current behavior?** (You can also link to an open issue here)
[Open issue](https://github.com/Semantic-UI-Vue/Semantic-UI-Vue/issues/397)

* **What is the new behavior (if this is a feature change)?**
sui-comment-group can accept collapsed as a prop, and will hide all child elements the same way
Semantic UI does [here](https://semantic-ui.com/views/comment.html#collapsed)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
As far as I am aware, no. But I have not considered every possible usage of this component 


* **Other information**:
Fair warning, this is my first contribution. 

Love this integration, thanks for the opportunity to contribute
